### PR TITLE
Add xlookup and logarithm operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# JsonLogic with Exponent Operator
+# JsonLogicXL - JsonLogic with excel formulas
 
-[JsonLogic](http://jsonlogic.com/) implementation in Elixir forked, added support for exponential operation
+[JsonLogic](http://jsonlogic.com/) implementation in Elixir forked, added some excel formulas such as the power operator `^`, a matching case operator `xlookup`, and natural log operator `ln`.
+
+Adding excel formulas as needed, not all excel formulas are implemented.
 
 ## Installation
 
-This package can be installed by adding `json_logic` to your list of dependencies in `mix.exs`:
+This package can be installed by adding `json_logic_plus_xl` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:json_logic_exponent, ">= 0.0.0"}
+    {:json_logic_plus_xl, ">= 0.0.0"}
   ]
 end
 ```

--- a/lib/extended_logic.ex
+++ b/lib/extended_logic.ex
@@ -1,0 +1,152 @@
+defmodule JSONLogic_ExtendedOperations do
+  @moduledoc """
+  Extended operators on top of the existing JSON Logic operators
+  """
+
+  @doc """
+  implements the exponential operator
+  """
+  def exponent_op(numbers, data) do
+    numbers
+    |> Enum.map(fn x -> JsonLogicXL.resolve(x, data) end)
+    |> Enum.reduce_while({nil, 0}, fn
+      number, {nil, total} ->
+        {:cont, {number, total}}
+      number, {base, total} when is_number(number) ->
+        {:cont, {base, total + number}}
+      %Decimal{} = decimal, {base, total} ->
+        # Convert Decimal to float
+        number = Decimal.to_float(decimal)
+        {:cont, {base, total + number}}
+      string, {base, total} when is_binary(string) ->
+        case parse_number(string) do
+          {:ok, number} ->
+            {:cont, {base, total + number}}
+
+          :error ->
+            {:cont, {base, total}}  # Continue accumulating valid base and exponents
+        end
+      _any, {base, total} ->
+        {:cont, {base, total}}  # Continue accumulating valid base and exponents
+    end)
+    |> case do
+      {base, exponent} when is_number(base) and is_number(exponent) ->
+        result = exponentiate(base, exponent)
+        result
+      {base, exponent} when is_binary(base) ->
+        # Convert base if it's a string
+        case parse_numeric(base) do
+          {:ok, base_number} ->
+            result = exponentiate(base_number, exponent)
+            result
+          :error ->
+            nil
+        end
+      {base, exponent} when is_struct(base, Decimal) ->
+          # Convert base from Decimal to float
+          base_float = Decimal.to_float(base)
+          result = exponentiate(base_float, exponent)
+          result
+      {_base, _exponent} ->
+        nil
+    end
+  end
+
+  defp exponentiate(%Decimal{} = left, right) when is_number(right) do
+    left_float = Decimal.to_float(left)
+    exponentiate(left_float, right)
+  end
+
+  defp exponentiate(left, %Decimal{} = right) when is_number(left) do
+    right_float = Decimal.to_float(right)
+    exponentiate(left, right_float)
+  end
+
+  defp exponentiate(left, right) when is_binary(left) do
+    case parse_numeric(left) do
+      {:ok, number} ->
+        exponentiate(number, right)
+      :error ->
+        nil
+    end
+  end
+
+  defp exponentiate(left, right) when is_binary(right) do
+    case parse_numeric(right) do
+      {:ok, number} ->
+        exponentiate(left, number)
+      :error ->
+        nil
+    end
+  end
+
+  defp exponentiate(base, exponent) when is_number(base) and is_number(exponent) do
+    Float.pow(float(base), float(exponent))
+  end
+
+  def parse_numeric(string) do
+    case Float.parse(string) do
+      {number, _} ->
+        {:ok, number}
+      :error ->
+        :error
+    end
+  end
+
+  defp parse_number(value) do
+    case Integer.parse(value) do
+      {integer, ""} ->
+        {:ok, integer}
+
+      _ ->
+        case Float.parse(value) do
+          {float, ""} ->
+            {:ok, float}
+
+          {float, "."} ->
+            {:ok, float}
+
+          _ ->
+            :error
+        end
+    end
+  end
+
+  def float(value) when is_integer(value), do: value * 1.0
+  def float(value) when is_float(value), do: value
+
+  @doc """
+  implements the xlookup operator
+  """
+  def xlookup_op([match, opts, map_key_prop, map_val_prop | _rest_of_list], data) do
+    xlookup(JsonLogicXL.resolve(match, data), JsonLogicXL.resolve(opts, data),
+      JsonLogicXL.resolve(map_key_prop, data), JsonLogicXL.resolve(map_val_prop, data))
+  end
+
+  defguardp xlookup_guard(match, opts, k_prop, v_prop) when is_binary(match) and is_list(opts)
+    and is_binary(k_prop) and is_binary(v_prop)
+
+  defp xlookup(match, options, key_prop, val_prop) when
+    xlookup_guard(match, options, key_prop, val_prop)
+  do
+    options |> Enum.find_value(fn opt ->
+      if opt[key_prop] == match, do: opt[val_prop]
+    end)
+  end
+
+  @doc """
+  implements the ln (natural log) operator
+  """
+  def natural_log_op(num, data) do
+    natural_log(JsonLogicXL.resolve(num, data))
+  end
+
+  defp natural_log(val) when is_binary(val) do
+    {:ok, num} = parse_number(val)
+    natural_log(num)
+  end
+
+  defp natural_log(val) when is_number(val) do
+    :math.log(val)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,11 @@
-defmodule JsonLogicExp.Mixfile do
+defmodule JsonLogicXL.Mixfile do
   use Mix.Project
 
   @version "1.0.0"
 
   def project do
     [
-      app: :json_logic_exponent,
+      app: :json_logic_plus_xl,
       package: package(),
       aliases: aliases(),
       version: @version,
@@ -53,7 +53,7 @@ defmodule JsonLogicExp.Mixfile do
 
   defp docs do
     [
-      main: "JsonLogicExp",
+      main: "JsonLogicXL",
       extras: docs_extras(),
       source_ref: "v#{@version}",
       source_url: "https://github.com/Anglepoint-Engineering/json_logic_elixir_extended"

--- a/test/json_logic_test.exs
+++ b/test/json_logic_test.exs
@@ -1,41 +1,41 @@
-defmodule JsonLogicExpTest do
+defmodule JsonLogicXLTest do
   use ExUnit.Case, async: true
 
   describe "non rules" do
     test "nil" do
-      assert JsonLogicExp.resolve(nil) == nil
+      assert JsonLogicXL.resolve(nil) == nil
     end
 
     test "empty map" do
-      assert JsonLogicExp.resolve(%{}) == %{}
+      assert JsonLogicXL.resolve(%{}) == %{}
     end
 
     test "true" do
-      assert JsonLogicExp.resolve(true) == true
+      assert JsonLogicXL.resolve(true) == true
     end
 
     test "false" do
-      assert JsonLogicExp.resolve(false) == false
+      assert JsonLogicXL.resolve(false) == false
     end
 
     test "integer" do
-      assert JsonLogicExp.resolve(17) == 17
+      assert JsonLogicXL.resolve(17) == 17
     end
 
     test "float" do
-      assert JsonLogicExp.resolve(3.14) == 3.14
+      assert JsonLogicXL.resolve(3.14) == 3.14
     end
 
     test "string" do
-      assert JsonLogicExp.resolve("apple") == "apple"
+      assert JsonLogicXL.resolve("apple") == "apple"
     end
 
     test "null" do
-      assert JsonLogicExp.resolve(nil) == nil
+      assert JsonLogicXL.resolve(nil) == nil
     end
 
     test "list of strings" do
-      assert JsonLogicExp.resolve(["a", "b"]) == ["a", "b"]
+      assert JsonLogicXL.resolve(["a", "b"]) == ["a", "b"]
     end
   end
 
@@ -43,23 +43,23 @@ defmodule JsonLogicExpTest do
     test "returns from array inside hash" do
       logic = %{"var" => "key.1"}
       data = %{"key" => %{"1" => "a"}}
-      assert JsonLogicExp.resolve(logic, data) == "a"
+      assert JsonLogicXL.resolve(logic, data) == "a"
 
       logic = %{"var" => "key.1"}
       data = %{"key" => ~w{a b}}
-      assert JsonLogicExp.resolve(logic, data) == "b"
+      assert JsonLogicXL.resolve(logic, data) == "b"
     end
   end
 
   describe "==" do
     test "nested true" do
       logic = %{"==" => [true, %{"==" => [1, 1]}]}
-      assert JsonLogicExp.resolve(logic)
+      assert JsonLogicXL.resolve(logic)
     end
 
     test "nested false" do
       logic = %{"==" => [false, %{"==" => [0, 1]}]}
-      assert JsonLogicExp.resolve(logic)
+      assert JsonLogicXL.resolve(logic)
     end
 
     test "integer, float, and decimal comparisons" do
@@ -67,44 +67,44 @@ defmodule JsonLogicExpTest do
       twos = [Decimal.new("2.0"), "2.0", "2", 2.0, 2]
 
       for left <- ones, right <- ones do
-        assert JsonLogicExp.resolve(%{"==" => [left, right]})
+        assert JsonLogicXL.resolve(%{"==" => [left, right]})
       end
 
       for left <- twos, right <- ones do
-        refute JsonLogicExp.resolve(%{"==" => [left, right]})
+        refute JsonLogicXL.resolve(%{"==" => [left, right]})
       end
 
       for left <- ones, right <- twos do
-        refute JsonLogicExp.resolve(%{"==" => [left, right]})
+        refute JsonLogicXL.resolve(%{"==" => [left, right]})
       end
 
       for left <- ones, right <- ones do
         logic = %{"==" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- twos, right <- ones do
         logic = %{"==" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- ones, right <- twos do
         logic = %{"==" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
-      assert JsonLogicExp.resolve(%{"==" => [3.14, 1.0 + 2.14]})
-      refute JsonLogicExp.resolve(%{"==" => [3.14, 3.1399999999999997]})
+      assert JsonLogicXL.resolve(%{"==" => [3.14, 1.0 + 2.14]})
+      refute JsonLogicXL.resolve(%{"==" => [3.14, 3.1399999999999997]})
     end
   end
 
   describe "!=" do
     test "nested true" do
-      assert JsonLogicExp.resolve(%{"!=" => [false, %{"!=" => [0, 1]}]})
+      assert JsonLogicXL.resolve(%{"!=" => [false, %{"!=" => [0, 1]}]})
     end
 
     test "nested false" do
-      assert JsonLogicExp.resolve(%{"!=" => [true, %{"!=" => [1, 1]}]})
+      assert JsonLogicXL.resolve(%{"!=" => [true, %{"!=" => [1, 1]}]})
     end
 
     test "integer, float, and decimal comparisons" do
@@ -112,186 +112,186 @@ defmodule JsonLogicExpTest do
       twos = [Decimal.new("2.0"), "2.0", "2", 2.0, 2]
 
       for left <- ones, right <- ones do
-        refute JsonLogicExp.resolve(%{"!=" => [left, right]})
+        refute JsonLogicXL.resolve(%{"!=" => [left, right]})
       end
 
       for left <- twos, right <- ones do
-        assert JsonLogicExp.resolve(%{"!=" => [left, right]})
+        assert JsonLogicXL.resolve(%{"!=" => [left, right]})
       end
 
       for left <- ones, right <- twos do
-        assert JsonLogicExp.resolve(%{"!=" => [left, right]})
+        assert JsonLogicXL.resolve(%{"!=" => [left, right]})
       end
 
       for left <- ones, right <- ones do
         logic = %{"!=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- twos, right <- ones do
         logic = %{"!=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- ones, right <- twos do
         logic = %{"!=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
-      refute JsonLogicExp.resolve(%{"!=" => [3.14, 1.0 + 2.14]})
-      assert JsonLogicExp.resolve(%{"!=" => [3.14, 3.1399999999999997]})
+      refute JsonLogicXL.resolve(%{"!=" => [3.14, 1.0 + 2.14]})
+      assert JsonLogicXL.resolve(%{"!=" => [3.14, 3.1399999999999997]})
     end
   end
 
   describe "===" do
     test "nested true" do
-      assert JsonLogicExp.resolve(%{"===" => [true, %{"===" => [1, 1]}]})
+      assert JsonLogicXL.resolve(%{"===" => [true, %{"===" => [1, 1]}]})
     end
 
     test "nested false" do
-      assert JsonLogicExp.resolve(%{"===" => [false, %{"===" => [1, 1.0]}]})
+      assert JsonLogicXL.resolve(%{"===" => [false, %{"===" => [1, 1.0]}]})
     end
 
     test "integer comparisons" do
-      assert JsonLogicExp.resolve(%{"===" => [1, 1]})
-      refute JsonLogicExp.resolve(%{"===" => [1, "1"]})
-      assert JsonLogicExp.resolve(%{"===" => ["1", "1"]})
-      refute JsonLogicExp.resolve(%{"===" => ["1", 1]})
+      assert JsonLogicXL.resolve(%{"===" => [1, 1]})
+      refute JsonLogicXL.resolve(%{"===" => [1, "1"]})
+      assert JsonLogicXL.resolve(%{"===" => ["1", "1"]})
+      refute JsonLogicXL.resolve(%{"===" => ["1", 1]})
 
-      refute JsonLogicExp.resolve(%{"===" => [1, 2]})
-      refute JsonLogicExp.resolve(%{"===" => [1, "2"]})
-      refute JsonLogicExp.resolve(%{"===" => ["1", "2"]})
-      refute JsonLogicExp.resolve(%{"===" => ["1", 2]})
+      refute JsonLogicXL.resolve(%{"===" => [1, 2]})
+      refute JsonLogicXL.resolve(%{"===" => [1, "2"]})
+      refute JsonLogicXL.resolve(%{"===" => ["1", "2"]})
+      refute JsonLogicXL.resolve(%{"===" => ["1", 2]})
     end
 
     test "float comparisons" do
-      assert JsonLogicExp.resolve(%{"===" => [1.0, 1.0]})
-      refute JsonLogicExp.resolve(%{"===" => [1.0, "1.0"]})
-      assert JsonLogicExp.resolve(%{"===" => ["1.0", "1.0"]})
-      refute JsonLogicExp.resolve(%{"===" => ["1.0", 1.0]})
+      assert JsonLogicXL.resolve(%{"===" => [1.0, 1.0]})
+      refute JsonLogicXL.resolve(%{"===" => [1.0, "1.0"]})
+      assert JsonLogicXL.resolve(%{"===" => ["1.0", "1.0"]})
+      refute JsonLogicXL.resolve(%{"===" => ["1.0", 1.0]})
 
-      refute JsonLogicExp.resolve(%{"===" => [1.0, 2.0]})
-      refute JsonLogicExp.resolve(%{"===" => [1.0, "2.0"]})
-      refute JsonLogicExp.resolve(%{"===" => ["1.0", "2.0"]})
-      refute JsonLogicExp.resolve(%{"===" => ["1.0", 2.0]})
+      refute JsonLogicXL.resolve(%{"===" => [1.0, 2.0]})
+      refute JsonLogicXL.resolve(%{"===" => [1.0, "2.0"]})
+      refute JsonLogicXL.resolve(%{"===" => ["1.0", "2.0"]})
+      refute JsonLogicXL.resolve(%{"===" => ["1.0", 2.0]})
     end
 
     test "decimal comparisons" do
-      refute JsonLogicExp.resolve(%{"===" => ["1.0", Decimal.new("1.0")]})
-      refute JsonLogicExp.resolve(%{"===" => [1.0, Decimal.new("1.0")]})
-      refute JsonLogicExp.resolve(%{"===" => [1, Decimal.new("1.0")]})
-      refute JsonLogicExp.resolve(%{"===" => [1, Decimal.new("1")]})
-      refute JsonLogicExp.resolve(%{"===" => [Decimal.new("1.0"), "1.0"]})
-      refute JsonLogicExp.resolve(%{"===" => [Decimal.new("1.0"), 1.0]})
-      refute JsonLogicExp.resolve(%{"===" => [Decimal.new("1.0"), 1]})
-      refute JsonLogicExp.resolve(%{"===" => [Decimal.new("1"), 1]})
+      refute JsonLogicXL.resolve(%{"===" => ["1.0", Decimal.new("1.0")]})
+      refute JsonLogicXL.resolve(%{"===" => [1.0, Decimal.new("1.0")]})
+      refute JsonLogicXL.resolve(%{"===" => [1, Decimal.new("1.0")]})
+      refute JsonLogicXL.resolve(%{"===" => [1, Decimal.new("1")]})
+      refute JsonLogicXL.resolve(%{"===" => [Decimal.new("1.0"), "1.0"]})
+      refute JsonLogicXL.resolve(%{"===" => [Decimal.new("1.0"), 1.0]})
+      refute JsonLogicXL.resolve(%{"===" => [Decimal.new("1.0"), 1]})
+      refute JsonLogicXL.resolve(%{"===" => [Decimal.new("1"), 1]})
 
-      assert JsonLogicExp.resolve(%{"===" => [Decimal.new("1.0"), Decimal.new("1.0")]})
-      refute JsonLogicExp.resolve(%{"===" => [Decimal.new("1.00"), Decimal.new("1.0")]})
-      refute JsonLogicExp.resolve(%{"===" => [Decimal.new("1.0"), Decimal.new("1.00")]})
+      assert JsonLogicXL.resolve(%{"===" => [Decimal.new("1.0"), Decimal.new("1.0")]})
+      refute JsonLogicXL.resolve(%{"===" => [Decimal.new("1.00"), Decimal.new("1.0")]})
+      refute JsonLogicXL.resolve(%{"===" => [Decimal.new("1.0"), Decimal.new("1.00")]})
     end
   end
 
   describe "!==" do
     test "nested true" do
-      assert JsonLogicExp.resolve(%{"!==" => [false, %{"!==" => [1, 1.0]}]})
+      assert JsonLogicXL.resolve(%{"!==" => [false, %{"!==" => [1, 1.0]}]})
     end
 
     test "nested false" do
-      assert JsonLogicExp.resolve(%{"!==" => [true, %{"!==" => [1, 1]}]})
+      assert JsonLogicXL.resolve(%{"!==" => [true, %{"!==" => [1, 1]}]})
     end
 
     test "integer comparisons" do
-      refute JsonLogicExp.resolve(%{"!==" => [1, 1]})
-      assert JsonLogicExp.resolve(%{"!==" => [1, 2]})
-      assert JsonLogicExp.resolve(%{"!==" => [1, "1"]})
-      refute JsonLogicExp.resolve(%{"!==" => ["1", "1"]})
-      assert JsonLogicExp.resolve(%{"!==" => ["1", 1]})
+      refute JsonLogicXL.resolve(%{"!==" => [1, 1]})
+      assert JsonLogicXL.resolve(%{"!==" => [1, 2]})
+      assert JsonLogicXL.resolve(%{"!==" => [1, "1"]})
+      refute JsonLogicXL.resolve(%{"!==" => ["1", "1"]})
+      assert JsonLogicXL.resolve(%{"!==" => ["1", 1]})
     end
 
     test "float comparisons" do
-      refute JsonLogicExp.resolve(%{"!==" => [1.0, 1.0]})
-      assert JsonLogicExp.resolve(%{"!==" => [1.0, 2.0]})
-      assert JsonLogicExp.resolve(%{"!==" => [1.0, "1.0"]})
-      refute JsonLogicExp.resolve(%{"!==" => ["1.0", "1.0"]})
-      assert JsonLogicExp.resolve(%{"!==" => ["1.0", 1.0]})
+      refute JsonLogicXL.resolve(%{"!==" => [1.0, 1.0]})
+      assert JsonLogicXL.resolve(%{"!==" => [1.0, 2.0]})
+      assert JsonLogicXL.resolve(%{"!==" => [1.0, "1.0"]})
+      refute JsonLogicXL.resolve(%{"!==" => ["1.0", "1.0"]})
+      assert JsonLogicXL.resolve(%{"!==" => ["1.0", 1.0]})
     end
 
     test "decimal comparisons" do
-      assert JsonLogicExp.resolve(%{"!==" => ["1.0", Decimal.new("1.0")]})
-      assert JsonLogicExp.resolve(%{"!==" => [1.0, Decimal.new("1.0")]})
-      assert JsonLogicExp.resolve(%{"!==" => [1, Decimal.new("1.0")]})
-      assert JsonLogicExp.resolve(%{"!==" => [1, Decimal.new("1")]})
-      assert JsonLogicExp.resolve(%{"!==" => [Decimal.new("1.0"), "1.0"]})
-      assert JsonLogicExp.resolve(%{"!==" => [Decimal.new("1.0"), 1.0]})
-      assert JsonLogicExp.resolve(%{"!==" => [Decimal.new("1.0"), 1]})
-      assert JsonLogicExp.resolve(%{"!==" => [Decimal.new("1"), 1]})
+      assert JsonLogicXL.resolve(%{"!==" => ["1.0", Decimal.new("1.0")]})
+      assert JsonLogicXL.resolve(%{"!==" => [1.0, Decimal.new("1.0")]})
+      assert JsonLogicXL.resolve(%{"!==" => [1, Decimal.new("1.0")]})
+      assert JsonLogicXL.resolve(%{"!==" => [1, Decimal.new("1")]})
+      assert JsonLogicXL.resolve(%{"!==" => [Decimal.new("1.0"), "1.0"]})
+      assert JsonLogicXL.resolve(%{"!==" => [Decimal.new("1.0"), 1.0]})
+      assert JsonLogicXL.resolve(%{"!==" => [Decimal.new("1.0"), 1]})
+      assert JsonLogicXL.resolve(%{"!==" => [Decimal.new("1"), 1]})
 
-      refute JsonLogicExp.resolve(%{"!==" => [Decimal.new("1.0"), Decimal.new("1.0")]})
-      assert JsonLogicExp.resolve(%{"!==" => [Decimal.new("1.00"), Decimal.new("1.0")]})
-      assert JsonLogicExp.resolve(%{"!==" => [Decimal.new("1.0"), Decimal.new("1.00")]})
+      refute JsonLogicXL.resolve(%{"!==" => [Decimal.new("1.0"), Decimal.new("1.0")]})
+      assert JsonLogicXL.resolve(%{"!==" => [Decimal.new("1.00"), Decimal.new("1.0")]})
+      assert JsonLogicXL.resolve(%{"!==" => [Decimal.new("1.0"), Decimal.new("1.00")]})
     end
   end
 
   describe "!" do
     test "returns true with [false]" do
-      assert JsonLogicExp.resolve(%{"!" => [false]})
+      assert JsonLogicXL.resolve(%{"!" => [false]})
     end
 
     test "returns false with [true]" do
-      refute JsonLogicExp.resolve(%{"!" => [true]})
+      refute JsonLogicXL.resolve(%{"!" => [true]})
     end
 
     test "returns true with [false] from data" do
       logic = %{"!" => [%{"var" => "key"}]}
       data = %{"key" => false}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
     end
 
     test "notting boolean" do
-      assert JsonLogicExp.resolve(%{"!" => [false]})
-      assert JsonLogicExp.resolve(%{"!" => false})
-      refute JsonLogicExp.resolve(%{"!" => [true]})
-      refute JsonLogicExp.resolve(%{"!" => true})
+      assert JsonLogicXL.resolve(%{"!" => [false]})
+      assert JsonLogicXL.resolve(%{"!" => false})
+      refute JsonLogicXL.resolve(%{"!" => [true]})
+      refute JsonLogicXL.resolve(%{"!" => true})
     end
 
     test "notting nil" do
-      assert JsonLogicExp.resolve(%{"!" => nil})
-      assert JsonLogicExp.resolve(%{"!" => [nil]})
-      refute JsonLogicExp.resolve(%{"!" => [nil, nil]})
+      assert JsonLogicXL.resolve(%{"!" => nil})
+      assert JsonLogicXL.resolve(%{"!" => [nil]})
+      refute JsonLogicXL.resolve(%{"!" => [nil, nil]})
     end
 
     test "notting numbers" do
-      assert JsonLogicExp.resolve(%{"!" => 0})
-      refute JsonLogicExp.resolve(%{"!" => 1})
-      refute JsonLogicExp.resolve(%{"!" => -1})
-      refute JsonLogicExp.resolve(%{"!" => 100})
-      refute JsonLogicExp.resolve(%{"!" => 0.0})
-      refute JsonLogicExp.resolve(%{"!" => 1.0})
-      refute JsonLogicExp.resolve(%{"!" => -1.0})
-      refute JsonLogicExp.resolve(%{"!" => Decimal.new("1.0")})
+      assert JsonLogicXL.resolve(%{"!" => 0})
+      refute JsonLogicXL.resolve(%{"!" => 1})
+      refute JsonLogicXL.resolve(%{"!" => -1})
+      refute JsonLogicXL.resolve(%{"!" => 100})
+      refute JsonLogicXL.resolve(%{"!" => 0.0})
+      refute JsonLogicXL.resolve(%{"!" => 1.0})
+      refute JsonLogicXL.resolve(%{"!" => -1.0})
+      refute JsonLogicXL.resolve(%{"!" => Decimal.new("1.0")})
     end
 
     test "notting vars" do
       logic = %{"!" => [%{"var" => "foo"}]}
       data = %{"foo" => 0}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"!" => [%{"var" => "foo"}]}
       data = %{"foo" => 1}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"!" => [%{"var" => "foo"}]}
       data = %{"foo" => 1.0}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"!" => [%{"var" => "foo"}]}
       data = %{"foo" => 0.0}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"!" => [%{"var" => "foo"}]}
       data = %{"foo" => Decimal.new("1.0")}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
     end
   end
 
@@ -299,92 +299,92 @@ defmodule JsonLogicExpTest do
     test "returns var when true" do
       logic = %{"if" => [true, %{"var" => "key"}, "unexpected"]}
       data = %{"key" => "yes"}
-      assert JsonLogicExp.resolve(logic, data) == "yes"
+      assert JsonLogicXL.resolve(logic, data) == "yes"
     end
 
     test "returns var when false" do
       logic = %{"if" => [false, "unexpected", %{"var" => "key"}]}
       data = %{"key" => "no"}
-      assert JsonLogicExp.resolve(logic, data) == "no"
+      assert JsonLogicXL.resolve(logic, data) == "no"
     end
 
     test "returns var with multiple branches" do
       logic = %{"if" => [false, "unexpected", false, "unexpected", %{"var" => "key"}]}
       data = %{"key" => "default"}
 
-      assert JsonLogicExp.resolve(logic, data) == "default"
+      assert JsonLogicXL.resolve(logic, data) == "default"
     end
 
     test "returns nil when else is not present" do
-      assert JsonLogicExp.resolve(%{"if" => [false, "unexpected"]}) == nil
+      assert JsonLogicXL.resolve(%{"if" => [false, "unexpected"]}) == nil
     end
 
     test "too few args" do
-      assert JsonLogicExp.resolve(%{"if" => []}) == nil
-      assert JsonLogicExp.resolve(%{"if" => [true]}) == true
-      assert JsonLogicExp.resolve(%{"if" => [false]}) == false
-      assert JsonLogicExp.resolve(%{"if" => ["apple"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => []}) == nil
+      assert JsonLogicXL.resolve(%{"if" => [true]}) == true
+      assert JsonLogicXL.resolve(%{"if" => [false]}) == false
+      assert JsonLogicXL.resolve(%{"if" => ["apple"]}) == "apple"
     end
 
     test "simple if then else cases" do
-      assert JsonLogicExp.resolve(%{"if" => [true, "apple"]}) == "apple"
-      assert JsonLogicExp.resolve(%{"if" => [false, "apple"]}) == nil
-      assert JsonLogicExp.resolve(%{"if" => [true, "apple", "banana"]}) == "apple"
-      assert JsonLogicExp.resolve(%{"if" => [false, "apple", "banana"]}) == "banana"
+      assert JsonLogicXL.resolve(%{"if" => [true, "apple"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [false, "apple"]}) == nil
+      assert JsonLogicXL.resolve(%{"if" => [true, "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [false, "apple", "banana"]}) == "banana"
     end
 
     test "empty arrays are falsey" do
-      assert JsonLogicExp.resolve(%{"if" => [[], "apple", "banana"]}) == "banana"
-      assert JsonLogicExp.resolve(%{"if" => [[1], "apple", "banana"]}) == "apple"
-      assert JsonLogicExp.resolve(%{"if" => [[1, 2, 3, 4], "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [[], "apple", "banana"]}) == "banana"
+      assert JsonLogicXL.resolve(%{"if" => [[1], "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [[1, 2, 3, 4], "apple", "banana"]}) == "apple"
     end
 
     test "empty strings are falsey, all other strings are truthy" do
-      assert JsonLogicExp.resolve(%{"if" => ["", "apple", "banana"]}) == "banana"
-      assert JsonLogicExp.resolve(%{"if" => ["zucchini", "apple", "banana"]}) == "apple"
-      assert JsonLogicExp.resolve(%{"if" => ["0", "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => ["", "apple", "banana"]}) == "banana"
+      assert JsonLogicXL.resolve(%{"if" => ["zucchini", "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => ["0", "apple", "banana"]}) == "apple"
     end
 
     test "you can cast a string to numeric with a unary + " do
-      assert JsonLogicExp.resolve(%{"===" => [0, "0"]}) == false
-      assert JsonLogicExp.resolve(%{"===" => [0, %{"+" => "0"}]}) == true
-      assert JsonLogicExp.resolve(%{"if" => ["", "apple", "banana"]}) == "banana"
-      assert JsonLogicExp.resolve(%{"if" => [%{"+" => "0"}, "apple", "banana"]}) == "banana"
-      assert JsonLogicExp.resolve(%{"if" => [%{"+" => "1"}, "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"===" => [0, "0"]}) == false
+      assert JsonLogicXL.resolve(%{"===" => [0, %{"+" => "0"}]}) == true
+      assert JsonLogicXL.resolve(%{"if" => ["", "apple", "banana"]}) == "banana"
+      assert JsonLogicXL.resolve(%{"if" => [%{"+" => "0"}, "apple", "banana"]}) == "banana"
+      assert JsonLogicXL.resolve(%{"if" => [%{"+" => "1"}, "apple", "banana"]}) == "apple"
     end
 
     test "zero is falsy, all other numbers are truthy" do
-      assert JsonLogicExp.resolve(%{"if" => [0, "apple", "banana"]}) == "banana"
-      assert JsonLogicExp.resolve(%{"if" => [1, "apple", "banana"]}) == "apple"
-      assert JsonLogicExp.resolve(%{"if" => [3.1416, "apple", "banana"]}) == "apple"
-      assert JsonLogicExp.resolve(%{"if" => [-1, "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [0, "apple", "banana"]}) == "banana"
+      assert JsonLogicXL.resolve(%{"if" => [1, "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [3.1416, "apple", "banana"]}) == "apple"
+      assert JsonLogicXL.resolve(%{"if" => [-1, "apple", "banana"]}) == "apple"
     end
 
     test "truthy and falsy definitions matter in boolean operations" do
-      assert JsonLogicExp.resolve(%{"!" => [[]]}) == true
-      assert JsonLogicExp.resolve(%{"!!" => [[]]}) == false
-      assert JsonLogicExp.resolve(%{"and" => [[], true]}) == []
-      assert JsonLogicExp.resolve(%{"or" => [[], true]}) == true
-      assert JsonLogicExp.resolve(%{"!" => [0]}) == true
-      assert JsonLogicExp.resolve(%{"!!" => [0]}) == false
-      assert JsonLogicExp.resolve(%{"and" => [0, true]}) == 0
-      assert JsonLogicExp.resolve(%{"or" => [0, true]}) == true
-      assert JsonLogicExp.resolve(%{"!" => [""]}) == true
-      assert JsonLogicExp.resolve(%{"!!" => [""]}) == false
-      assert JsonLogicExp.resolve(%{"and" => ["", true]}) == ""
-      assert JsonLogicExp.resolve(%{"or" => ["", true]}) == true
-      assert JsonLogicExp.resolve(%{"!" => ["0"]}) == false
-      assert JsonLogicExp.resolve(%{"!!" => ["0"]}) == true
-      assert JsonLogicExp.resolve(%{"and" => ["0", true]}) == true
-      assert JsonLogicExp.resolve(%{"or" => ["0", true]}) == "0"
+      assert JsonLogicXL.resolve(%{"!" => [[]]}) == true
+      assert JsonLogicXL.resolve(%{"!!" => [[]]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [[], true]}) == []
+      assert JsonLogicXL.resolve(%{"or" => [[], true]}) == true
+      assert JsonLogicXL.resolve(%{"!" => [0]}) == true
+      assert JsonLogicXL.resolve(%{"!!" => [0]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [0, true]}) == 0
+      assert JsonLogicXL.resolve(%{"or" => [0, true]}) == true
+      assert JsonLogicXL.resolve(%{"!" => [""]}) == true
+      assert JsonLogicXL.resolve(%{"!!" => [""]}) == false
+      assert JsonLogicXL.resolve(%{"and" => ["", true]}) == ""
+      assert JsonLogicXL.resolve(%{"or" => ["", true]}) == true
+      assert JsonLogicXL.resolve(%{"!" => ["0"]}) == false
+      assert JsonLogicXL.resolve(%{"!!" => ["0"]}) == true
+      assert JsonLogicXL.resolve(%{"and" => ["0", true]}) == true
+      assert JsonLogicXL.resolve(%{"or" => ["0", true]}) == "0"
     end
 
     test "if the conditional is logic, it gets evaluated" do
       logic = %{"if" => [%{">" => [2, 1]}, "apple", "banana"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [%{">" => [1, 2]}, "apple", "banana"]}
-      assert JsonLogicExp.resolve(logic) == "banana"
+      assert JsonLogicXL.resolve(logic) == "banana"
     end
 
     test "if the consequents are logic, they get evaluated" do
@@ -396,7 +396,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{
         "if" => [
@@ -406,60 +406,60 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic) == "banana"
+      assert JsonLogicXL.resolve(logic) == "banana"
     end
 
     test "if / then / elseif / then cases" do
       logic = %{"if" => [true, "apple", true, "banana"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [true, "apple", false, "banana"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [false, "apple", true, "banana"]}
-      assert JsonLogicExp.resolve(logic) == "banana"
+      assert JsonLogicXL.resolve(logic) == "banana"
 
       logic = %{"if" => [false, "apple", false, "banana"]}
-      assert JsonLogicExp.resolve(logic) == nil
+      assert JsonLogicXL.resolve(logic) == nil
 
       logic = %{"if" => [true, "apple", true, "banana", "carrot"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [true, "apple", false, "banana", "carrot"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [false, "apple", true, "banana", "carrot"]}
-      assert JsonLogicExp.resolve(logic) == "banana"
+      assert JsonLogicXL.resolve(logic) == "banana"
 
       logic = %{"if" => [false, "apple", false, "banana", "carrot"]}
-      assert JsonLogicExp.resolve(logic) == "carrot"
+      assert JsonLogicXL.resolve(logic) == "carrot"
 
       logic = %{"if" => [false, "apple", false, "banana", false, "carrot"]}
-      assert JsonLogicExp.resolve(logic) == nil
+      assert JsonLogicXL.resolve(logic) == nil
 
       logic = %{"if" => [false, "apple", false, "banana", false, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "date"
+      assert JsonLogicXL.resolve(logic) == "date"
 
       logic = %{"if" => [false, "apple", false, "banana", true, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "carrot"
+      assert JsonLogicXL.resolve(logic) == "carrot"
 
       logic = %{"if" => [false, "apple", true, "banana", false, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "banana"
+      assert JsonLogicXL.resolve(logic) == "banana"
 
       logic = %{"if" => [false, "apple", true, "banana", true, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "banana"
+      assert JsonLogicXL.resolve(logic) == "banana"
 
       logic = %{"if" => [true, "apple", false, "banana", false, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [true, "apple", false, "banana", true, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [true, "apple", true, "banana", false, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
 
       logic = %{"if" => [true, "apple", true, "banana", true, "carrot", "date"]}
-      assert JsonLogicExp.resolve(logic) == "apple"
+      assert JsonLogicXL.resolve(logic) == "apple"
     end
 
     test "returns object" do
@@ -476,7 +476,7 @@ defmodule JsonLogicExpTest do
       assert %{
                "foo" => "is_bar",
                "path" => "foo_is_bar"
-             } == JsonLogicExp.resolve(logic, data)
+             } == JsonLogicXL.resolve(logic, data)
     end
   end
 
@@ -484,46 +484,46 @@ defmodule JsonLogicExpTest do
     test "returns max from vars" do
       logic = %{"max" => [%{"var" => "three"}, %{"var" => "one"}, %{"var" => "two"}]}
       data = %{"one" => 1, "two" => 2, "three" => 3}
-      assert JsonLogicExp.resolve(logic, data) == 3
+      assert JsonLogicXL.resolve(logic, data) == 3
     end
 
     test "integers" do
-      assert JsonLogicExp.resolve(%{"max" => [1, 2, 3]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [1, 3, 3]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [3, 2, 1]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [3, 2]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [1]}) == 1
+      assert JsonLogicXL.resolve(%{"max" => [1, 2, 3]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [1, 3, 3]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [3, 2, 1]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [3, 2]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [1]}) == 1
 
-      assert JsonLogicExp.resolve(%{"max" => ["1", "2", "3"]}) == "3"
-      assert JsonLogicExp.resolve(%{"max" => ["1", "3", "3"]}) == "3"
-      assert JsonLogicExp.resolve(%{"max" => ["3", "2", "1"]}) == "3"
-      assert JsonLogicExp.resolve(%{"max" => ["3", "2"]}) == "3"
-      assert JsonLogicExp.resolve(%{"max" => ["1"]}) == "1"
+      assert JsonLogicXL.resolve(%{"max" => ["1", "2", "3"]}) == "3"
+      assert JsonLogicXL.resolve(%{"max" => ["1", "3", "3"]}) == "3"
+      assert JsonLogicXL.resolve(%{"max" => ["3", "2", "1"]}) == "3"
+      assert JsonLogicXL.resolve(%{"max" => ["3", "2"]}) == "3"
+      assert JsonLogicXL.resolve(%{"max" => ["1"]}) == "1"
 
-      assert JsonLogicExp.resolve(%{"max" => ["1", "2", 3]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [3, "2", "1"]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [3, "2"]}) == 3
-      assert JsonLogicExp.resolve(%{"max" => [1]}) == 1
+      assert JsonLogicXL.resolve(%{"max" => ["1", "2", 3]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [3, "2", "1"]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [3, "2"]}) == 3
+      assert JsonLogicXL.resolve(%{"max" => [1]}) == 1
     end
 
     test "floats" do
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => [1.1, 2.1, 3.1]}))
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => [1.1, 3.1, 3.1]}))
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => [3.1, 2.1, 1.1]}))
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => [3.1, 2.1]}))
-      assert_approx_eq(1.1, JsonLogicExp.resolve(%{"max" => [1.1]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => [1.1, 2.1, 3.1]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => [1.1, 3.1, 3.1]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => [3.1, 2.1, 1.1]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => [3.1, 2.1]}))
+      assert_approx_eq(1.1, JsonLogicXL.resolve(%{"max" => [1.1]}))
 
-      assert JsonLogicExp.resolve(%{"max" => ["1.1", "2.1", "3.1"]}) == "3.1"
-      assert JsonLogicExp.resolve(%{"max" => ["1.1", "3.1", "3.1"]}) == "3.1"
-      assert JsonLogicExp.resolve(%{"max" => ["3.1", "2.1", "1.1"]}) == "3.1"
-      assert JsonLogicExp.resolve(%{"max" => ["3.", "2.1", "1.1"]}) == "3."
-      assert JsonLogicExp.resolve(%{"max" => ["3.1", "2.1"]}) == "3.1"
-      assert JsonLogicExp.resolve(%{"max" => ["1.1"]}) == "1.1"
-      assert JsonLogicExp.resolve(%{"max" => ["1."]}) == "1."
+      assert JsonLogicXL.resolve(%{"max" => ["1.1", "2.1", "3.1"]}) == "3.1"
+      assert JsonLogicXL.resolve(%{"max" => ["1.1", "3.1", "3.1"]}) == "3.1"
+      assert JsonLogicXL.resolve(%{"max" => ["3.1", "2.1", "1.1"]}) == "3.1"
+      assert JsonLogicXL.resolve(%{"max" => ["3.", "2.1", "1.1"]}) == "3."
+      assert JsonLogicXL.resolve(%{"max" => ["3.1", "2.1"]}) == "3.1"
+      assert JsonLogicXL.resolve(%{"max" => ["1.1"]}) == "1.1"
+      assert JsonLogicXL.resolve(%{"max" => ["1."]}) == "1."
 
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => ["1.1", "2.1", 3.1]}))
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => [3.1, "2.1", "1.1"]}))
-      assert_approx_eq(3.1, JsonLogicExp.resolve(%{"max" => [3.1, "2.1"]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => ["1.1", "2.1", 3.1]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => [3.1, "2.1", "1.1"]}))
+      assert_approx_eq(3.1, JsonLogicXL.resolve(%{"max" => [3.1, "2.1"]}))
     end
 
     test "integer, floats, and decimals" do
@@ -532,16 +532,16 @@ defmodule JsonLogicExpTest do
       threes = [3, 3.0, "3", "3.0", Decimal.new("3.0")]
 
       for one <- ones, two <- twos, three <- threes do
-        assert_approx_eq(3, JsonLogicExp.resolve(%{"max" => [one, two, three]}))
+        assert_approx_eq(3, JsonLogicXL.resolve(%{"max" => [one, two, three]}))
       end
     end
 
     test "list with non numeric value" do
-      assert JsonLogicExp.resolve(%{"max" => ["1", "2", "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"max" => ["1", "2", "foo"]}) == nil
     end
 
     test "empty list" do
-      assert JsonLogicExp.resolve(%{"max" => []}) == nil
+      assert JsonLogicXL.resolve(%{"max" => []}) == nil
     end
   end
 
@@ -550,43 +550,43 @@ defmodule JsonLogicExpTest do
       logic = %{"min" => [%{"var" => "three"}, %{"var" => "one"}, %{"var" => "two"}]}
       data = %{"one" => 1, "two" => 2, "three" => 3}
 
-      assert JsonLogicExp.resolve(logic, data) == 1
+      assert JsonLogicXL.resolve(logic, data) == 1
     end
 
     test "integers" do
-      assert JsonLogicExp.resolve(%{"min" => [1, 2, 3]}) == 1
-      assert JsonLogicExp.resolve(%{"min" => [1, 3, 3]}) == 1
-      assert JsonLogicExp.resolve(%{"min" => [3, 2, 1]}) == 1
-      assert JsonLogicExp.resolve(%{"min" => [3, 2]}) == 2
-      assert JsonLogicExp.resolve(%{"min" => [1]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => [1, 2, 3]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => [1, 3, 3]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => [3, 2, 1]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => [3, 2]}) == 2
+      assert JsonLogicXL.resolve(%{"min" => [1]}) == 1
 
-      assert JsonLogicExp.resolve(%{"min" => ["1", "2", "3"]}) == "1"
-      assert JsonLogicExp.resolve(%{"min" => ["1", "3", "3"]}) == "1"
-      assert JsonLogicExp.resolve(%{"min" => ["3", "2", "1"]}) == "1"
-      assert JsonLogicExp.resolve(%{"min" => ["3", "2"]}) == "2"
-      assert JsonLogicExp.resolve(%{"min" => ["1"]}) == "1"
+      assert JsonLogicXL.resolve(%{"min" => ["1", "2", "3"]}) == "1"
+      assert JsonLogicXL.resolve(%{"min" => ["1", "3", "3"]}) == "1"
+      assert JsonLogicXL.resolve(%{"min" => ["3", "2", "1"]}) == "1"
+      assert JsonLogicXL.resolve(%{"min" => ["3", "2"]}) == "2"
+      assert JsonLogicXL.resolve(%{"min" => ["1"]}) == "1"
 
-      assert JsonLogicExp.resolve(%{"min" => [1, "2", "3"]}) == 1
-      assert JsonLogicExp.resolve(%{"min" => [1, "3", "3"]}) == 1
-      assert JsonLogicExp.resolve(%{"min" => ["3", "2", 1]}) == 1
-      assert JsonLogicExp.resolve(%{"min" => ["3", 2]}) == 2
+      assert JsonLogicXL.resolve(%{"min" => [1, "2", "3"]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => [1, "3", "3"]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => ["3", "2", 1]}) == 1
+      assert JsonLogicXL.resolve(%{"min" => ["3", 2]}) == 2
     end
 
     test "floats" do
-      assert JsonLogicExp.resolve(%{"min" => [1.1, 2.1, 3.1]}) == 1.1
-      assert JsonLogicExp.resolve(%{"min" => [1.1, 3.1, 3.1]}) == 1.1
-      assert JsonLogicExp.resolve(%{"min" => [3.1, 2.1, 1.1]}) == 1.1
-      assert JsonLogicExp.resolve(%{"min" => [3.1, 2.1]}) == 2.1
-      assert JsonLogicExp.resolve(%{"min" => [1.1]}) == 1.1
+      assert JsonLogicXL.resolve(%{"min" => [1.1, 2.1, 3.1]}) == 1.1
+      assert JsonLogicXL.resolve(%{"min" => [1.1, 3.1, 3.1]}) == 1.1
+      assert JsonLogicXL.resolve(%{"min" => [3.1, 2.1, 1.1]}) == 1.1
+      assert JsonLogicXL.resolve(%{"min" => [3.1, 2.1]}) == 2.1
+      assert JsonLogicXL.resolve(%{"min" => [1.1]}) == 1.1
 
-      assert JsonLogicExp.resolve(%{"min" => ["1.1", "2.1", "3.1"]}) == "1.1"
-      assert JsonLogicExp.resolve(%{"min" => ["1.1", "3.1", "3.1"]}) == "1.1"
-      assert JsonLogicExp.resolve(%{"min" => ["3.1", "2.1", "1.1"]}) == "1.1"
-      assert JsonLogicExp.resolve(%{"min" => ["3.1", "2.1"]}) == "2.1"
-      assert JsonLogicExp.resolve(%{"min" => ["1.1"]}) == "1.1"
+      assert JsonLogicXL.resolve(%{"min" => ["1.1", "2.1", "3.1"]}) == "1.1"
+      assert JsonLogicXL.resolve(%{"min" => ["1.1", "3.1", "3.1"]}) == "1.1"
+      assert JsonLogicXL.resolve(%{"min" => ["3.1", "2.1", "1.1"]}) == "1.1"
+      assert JsonLogicXL.resolve(%{"min" => ["3.1", "2.1"]}) == "2.1"
+      assert JsonLogicXL.resolve(%{"min" => ["1.1"]}) == "1.1"
 
-      assert JsonLogicExp.resolve(%{"min" => ["1.", "2.1", "3.1"]}) == "1."
-      assert JsonLogicExp.resolve(%{"min" => ["1."]}) == "1."
+      assert JsonLogicXL.resolve(%{"min" => ["1.", "2.1", "3.1"]}) == "1."
+      assert JsonLogicXL.resolve(%{"min" => ["1."]}) == "1."
     end
 
     test "integer, floats, and decimals" do
@@ -595,16 +595,16 @@ defmodule JsonLogicExpTest do
       threes = [3, 3.0, "3", "3.0", Decimal.new("3.0")]
 
       for one <- ones, two <- twos, three <- threes do
-        assert_approx_eq(1, JsonLogicExp.resolve(%{"min" => [one, two, three]}))
+        assert_approx_eq(1, JsonLogicXL.resolve(%{"min" => [one, two, three]}))
       end
     end
 
     test "list with non numeric value" do
-      assert JsonLogicExp.resolve(%{"min" => ["1", "2", "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"min" => ["1", "2", "foo"]}) == nil
     end
 
     test "empty list" do
-      assert JsonLogicExp.resolve(%{"min" => []}) == nil
+      assert JsonLogicXL.resolve(%{"min" => []}) == nil
     end
   end
 
@@ -612,34 +612,34 @@ defmodule JsonLogicExpTest do
     test "returns added result of vars" do
       logic = %{"+" => [%{"var" => "left"}, %{"var" => "right"}]}
       data = %{"left" => 5, "right" => 2}
-      assert JsonLogicExp.resolve(logic, data) == 7
+      assert JsonLogicXL.resolve(logic, data) == 7
     end
 
     test "handles empty list" do
-      assert JsonLogicExp.resolve(%{"+" => []}) == 0
+      assert JsonLogicXL.resolve(%{"+" => []}) == 0
     end
 
     test "integer addition" do
-      assert JsonLogicExp.resolve(%{"+" => [1, 2]}) == 3
-      assert JsonLogicExp.resolve(%{"+" => [1, 2, 3]}) == 6
-      assert JsonLogicExp.resolve(%{"+" => [1, 2, 3, 4]}) == 10
-      assert JsonLogicExp.resolve(%{"+" => [1]}) == 1
+      assert JsonLogicXL.resolve(%{"+" => [1, 2]}) == 3
+      assert JsonLogicXL.resolve(%{"+" => [1, 2, 3]}) == 6
+      assert JsonLogicXL.resolve(%{"+" => [1, 2, 3, 4]}) == 10
+      assert JsonLogicXL.resolve(%{"+" => [1]}) == 1
 
-      assert JsonLogicExp.resolve(%{"+" => [1, "2"]}) == 3
-      assert JsonLogicExp.resolve(%{"+" => [1, 2, "3"]}) == 6
-      assert JsonLogicExp.resolve(%{"+" => [1, "2", "3", 4]}) == 10
-      assert JsonLogicExp.resolve(%{"+" => ["1"]}) == 1
-      assert JsonLogicExp.resolve(%{"+" => ["1", 1]}) == 2
+      assert JsonLogicXL.resolve(%{"+" => [1, "2"]}) == 3
+      assert JsonLogicXL.resolve(%{"+" => [1, 2, "3"]}) == 6
+      assert JsonLogicXL.resolve(%{"+" => [1, "2", "3", 4]}) == 10
+      assert JsonLogicXL.resolve(%{"+" => ["1"]}) == 1
+      assert JsonLogicXL.resolve(%{"+" => ["1", 1]}) == 2
     end
 
     test "float addition" do
-      assert_approx_eq(3.14, JsonLogicExp.resolve(%{"+" => ["3.14"]}))
-      assert_approx_eq(3.14, JsonLogicExp.resolve(%{"+" => ["1.14", "2.0"]}))
+      assert_approx_eq(3.14, JsonLogicXL.resolve(%{"+" => ["3.14"]}))
+      assert_approx_eq(3.14, JsonLogicXL.resolve(%{"+" => ["1.14", "2.0"]}))
     end
 
     test "float addition with mixed integer" do
-      assert_approx_eq(3.14, JsonLogicExp.resolve(%{"+" => ["1.14", "2"]}))
-      assert_approx_eq(3.14, JsonLogicExp.resolve(%{"+" => ["1.14", 2]}))
+      assert_approx_eq(3.14, JsonLogicXL.resolve(%{"+" => ["1.14", "2"]}))
+      assert_approx_eq(3.14, JsonLogicXL.resolve(%{"+" => ["1.14", 2]}))
     end
 
     test "integer, float, and decimal addition" do
@@ -647,7 +647,7 @@ defmodule JsonLogicExpTest do
       twos = [2, 2.0, "2", "2.0", Decimal.new("2.0")]
 
       for left <- ones, right <- twos do
-        assert_approx_eq(3, JsonLogicExp.resolve(%{"+" => [left, right]}))
+        assert_approx_eq(3, JsonLogicXL.resolve(%{"+" => [left, right]}))
       end
     end
   end
@@ -656,46 +656,46 @@ defmodule JsonLogicExpTest do
     test "returns subtraced result of vars" do
       logic = %{"-" => [%{"var" => "left"}, %{"var" => "right"}]}
       data = %{"left" => 5, "right" => 2}
-      assert JsonLogicExp.resolve(logic, data) == 3
+      assert JsonLogicXL.resolve(logic, data) == 3
     end
 
     test "returns negative of a var" do
-      assert JsonLogicExp.resolve(%{"-" => [%{"var" => "key"}]}, %{"key" => 2}) == -2
+      assert JsonLogicXL.resolve(%{"-" => [%{"var" => "key"}]}, %{"key" => 2}) == -2
     end
 
     test "handles empty list" do
-      assert JsonLogicExp.resolve(%{"-" => []}) == nil
+      assert JsonLogicXL.resolve(%{"-" => []}) == nil
     end
 
     test "floating point handles" do
-      assert_approx_eq(-1.1, JsonLogicExp.resolve(%{"-" => [1.1, 2.2]}))
-      assert_approx_eq(-1.2, JsonLogicExp.resolve(%{"-" => ["1.", 2.2]}))
-      assert_approx_eq(7.8, JsonLogicExp.resolve(%{"-" => ["1.0e1", 2.2]}))
-      assert_approx_eq(7.8, JsonLogicExp.resolve(%{"-" => ["1.0E1", 2.2]}))
-      assert_approx_eq(7.8, JsonLogicExp.resolve(%{"-" => ["1.0E+1", 2.2]}))
+      assert_approx_eq(-1.1, JsonLogicXL.resolve(%{"-" => [1.1, 2.2]}))
+      assert_approx_eq(-1.2, JsonLogicXL.resolve(%{"-" => ["1.", 2.2]}))
+      assert_approx_eq(7.8, JsonLogicXL.resolve(%{"-" => ["1.0e1", 2.2]}))
+      assert_approx_eq(7.8, JsonLogicXL.resolve(%{"-" => ["1.0E1", 2.2]}))
+      assert_approx_eq(7.8, JsonLogicXL.resolve(%{"-" => ["1.0E+1", 2.2]}))
 
-      assert JsonLogicExp.resolve(%{"-" => ["1.0F+1", 2.2]}) == nil
+      assert JsonLogicXL.resolve(%{"-" => ["1.0F+1", 2.2]}) == nil
     end
 
     test "specification" do
-      assert JsonLogicExp.resolve(%{"-" => [1, 2]}) == -1
-      assert JsonLogicExp.resolve(%{"-" => [3, 2]}) == 1
-      assert JsonLogicExp.resolve(%{"-" => [3]}) == -3
-      assert JsonLogicExp.resolve(%{"-" => [-3]}) == 3
+      assert JsonLogicXL.resolve(%{"-" => [1, 2]}) == -1
+      assert JsonLogicXL.resolve(%{"-" => [3, 2]}) == 1
+      assert JsonLogicXL.resolve(%{"-" => [3]}) == -3
+      assert JsonLogicXL.resolve(%{"-" => [-3]}) == 3
 
-      assert JsonLogicExp.resolve(%{"-" => ["1", "2"]}) == -1
-      assert JsonLogicExp.resolve(%{"-" => ["3", "2"]}) == 1
-      assert JsonLogicExp.resolve(%{"-" => ["3"]}) == -3
-      assert JsonLogicExp.resolve(%{"-" => ["-3"]}) == 3
+      assert JsonLogicXL.resolve(%{"-" => ["1", "2"]}) == -1
+      assert JsonLogicXL.resolve(%{"-" => ["3", "2"]}) == 1
+      assert JsonLogicXL.resolve(%{"-" => ["3"]}) == -3
+      assert JsonLogicXL.resolve(%{"-" => ["-3"]}) == 3
 
-      assert JsonLogicExp.resolve(%{"-" => ["1", 2]}) == -1
-      assert JsonLogicExp.resolve(%{"-" => ["3", 2]}) == 1
+      assert JsonLogicXL.resolve(%{"-" => ["1", 2]}) == -1
+      assert JsonLogicXL.resolve(%{"-" => ["3", 2]}) == 1
 
-      assert JsonLogicExp.resolve(%{"-" => ["-1", 2]}) == -3
-      assert JsonLogicExp.resolve(%{"-" => ["-3", 2]}) == -5
+      assert JsonLogicXL.resolve(%{"-" => ["-1", 2]}) == -3
+      assert JsonLogicXL.resolve(%{"-" => ["-3", 2]}) == -5
 
-      assert JsonLogicExp.resolve(%{"-" => [1, "2"]}) == -1
-      assert JsonLogicExp.resolve(%{"-" => [3, "2"]}) == 1
+      assert JsonLogicXL.resolve(%{"-" => [1, "2"]}) == -1
+      assert JsonLogicXL.resolve(%{"-" => [3, "2"]}) == 1
     end
 
     test "integer, float, and decimal subtraction" do
@@ -703,7 +703,7 @@ defmodule JsonLogicExpTest do
       twos = [2, 2.0, "2", "2.0", Decimal.new("2.0")]
 
       for left <- ones, right <- twos do
-        assert_approx_eq(-1, JsonLogicExp.resolve(%{"-" => [left, right]}))
+        assert_approx_eq(-1, JsonLogicXL.resolve(%{"-" => [left, right]}))
       end
     end
   end
@@ -712,38 +712,38 @@ defmodule JsonLogicExpTest do
     test "returns multiplied result of vars" do
       logic = %{"*" => [%{"var" => "left"}, %{"var" => "right"}]}
       data = %{"left" => 5, "right" => 2}
-      assert JsonLogicExp.resolve(logic, data) == 10
+      assert JsonLogicXL.resolve(logic, data) == 10
     end
 
     test "strings being multipled" do
-      assert JsonLogicExp.resolve(%{"*" => ["a", "b"]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => ["a"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["a", "b"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["a"]}) == nil
     end
 
     test "integer multiplication" do
-      assert JsonLogicExp.resolve(%{"*" => [1, 2]}) == 2
-      assert JsonLogicExp.resolve(%{"*" => [1, 2, 3]}) == 6
-      assert JsonLogicExp.resolve(%{"*" => [1, 2, 3, 4]}) == 24
-      assert JsonLogicExp.resolve(%{"*" => [1]}) == 1
+      assert JsonLogicXL.resolve(%{"*" => [1, 2]}) == 2
+      assert JsonLogicXL.resolve(%{"*" => [1, 2, 3]}) == 6
+      assert JsonLogicXL.resolve(%{"*" => [1, 2, 3, 4]}) == 24
+      assert JsonLogicXL.resolve(%{"*" => [1]}) == 1
 
-      assert JsonLogicExp.resolve(%{"*" => [1, "2"]}) == 2
-      assert JsonLogicExp.resolve(%{"*" => [1, 2, "3"]}) == 6
-      assert JsonLogicExp.resolve(%{"*" => [1, "2", "3", 4]}) == 24
-      assert JsonLogicExp.resolve(%{"*" => ["1"]}) == 1
-      assert JsonLogicExp.resolve(%{"*" => ["1", 1]}) == 1
+      assert JsonLogicXL.resolve(%{"*" => [1, "2"]}) == 2
+      assert JsonLogicXL.resolve(%{"*" => [1, 2, "3"]}) == 6
+      assert JsonLogicXL.resolve(%{"*" => [1, "2", "3", 4]}) == 24
+      assert JsonLogicXL.resolve(%{"*" => ["1"]}) == 1
+      assert JsonLogicXL.resolve(%{"*" => ["1", 1]}) == 1
     end
 
     test "float multiplication" do
-      assert JsonLogicExp.resolve(%{"*" => [1.0, 2.0]}) == 2.0
-      assert JsonLogicExp.resolve(%{"*" => [1.0, 2.0, 3.0]}) == 6.0
-      assert JsonLogicExp.resolve(%{"*" => [1.0, 2.0, 3.0, 4.0]}) == 24.0
-      assert JsonLogicExp.resolve(%{"*" => [1.0]}) == 1.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0, 2.0]}) == 2.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0, 2.0, 3.0]}) == 6.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0, 2.0, 3.0, 4.0]}) == 24.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0]}) == 1.0
 
-      assert JsonLogicExp.resolve(%{"*" => [1.0, "2.0"]}) == 2.0
-      assert JsonLogicExp.resolve(%{"*" => [1.0, 2.0, "3.0"]}) == 6.0
-      assert JsonLogicExp.resolve(%{"*" => [1.0, "2.0", "3.0", 4.0]}) == 24.0
-      assert JsonLogicExp.resolve(%{"*" => ["1.0"]}) == 1.0
-      assert JsonLogicExp.resolve(%{"*" => ["1.0", 1.0]}) == 1.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0, "2.0"]}) == 2.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0, 2.0, "3.0"]}) == 6.0
+      assert JsonLogicXL.resolve(%{"*" => [1.0, "2.0", "3.0", 4.0]}) == 24.0
+      assert JsonLogicXL.resolve(%{"*" => ["1.0"]}) == 1.0
+      assert JsonLogicXL.resolve(%{"*" => ["1.0", 1.0]}) == 1.0
     end
 
     test "decimal multiplication" do
@@ -752,13 +752,13 @@ defmodule JsonLogicExpTest do
       for left <- twos, right <- twos do
         assert_approx_eq(
           Decimal.new("4.0"),
-          JsonLogicExp.resolve(%{"*" => [left, right]})
+          JsonLogicXL.resolve(%{"*" => [left, right]})
         )
       end
 
       assert_approx_eq(
         Decimal.new("8.0"),
-        JsonLogicExp.resolve(%{
+        JsonLogicXL.resolve(%{
           "*" => [
             Decimal.new("2.0"),
             Decimal.new("2.0"),
@@ -767,14 +767,14 @@ defmodule JsonLogicExpTest do
         })
       )
 
-      assert JsonLogicExp.resolve(%{"*" => ["1", "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => [1, "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => [1.0, "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => ["1.0", "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => ["foo", "1"]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => ["foo", 1]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => ["foo", 1.0]}) == nil
-      assert JsonLogicExp.resolve(%{"*" => ["foo", "1.0"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["1", "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => [1, "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => [1.0, "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["1.0", "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["foo", "1"]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["foo", 1]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["foo", 1.0]}) == nil
+      assert JsonLogicXL.resolve(%{"*" => ["foo", "1.0"]}) == nil
     end
   end
 
@@ -782,30 +782,30 @@ defmodule JsonLogicExpTest do
     test "returns multiplied result of vars" do
       logic = %{"/" => [%{"var" => "left"}, %{"var" => "right"}]}
       data = %{"left" => 5, "right" => 2}
-      assert JsonLogicExp.resolve(logic, data) == 2.5
+      assert JsonLogicXL.resolve(logic, data) == 2.5
     end
 
     test "integer division" do
-      assert JsonLogicExp.resolve(%{"/" => [4, 2]}) == 2
-      assert JsonLogicExp.resolve(%{"/" => [4, "2"]}) == 2
-      assert JsonLogicExp.resolve(%{"/" => ["4", "2"]}) == 2
-      assert JsonLogicExp.resolve(%{"/" => ["4", 2]}) == 2
+      assert JsonLogicXL.resolve(%{"/" => [4, 2]}) == 2
+      assert JsonLogicXL.resolve(%{"/" => [4, "2"]}) == 2
+      assert JsonLogicXL.resolve(%{"/" => ["4", "2"]}) == 2
+      assert JsonLogicXL.resolve(%{"/" => ["4", 2]}) == 2
 
-      assert JsonLogicExp.resolve(%{"/" => [2, 4]}) == 0.5
-      assert JsonLogicExp.resolve(%{"/" => ["2", 4]}) == 0.5
-      assert JsonLogicExp.resolve(%{"/" => ["2", "4"]}) == 0.5
-      assert JsonLogicExp.resolve(%{"/" => [2, "4"]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => [2, 4]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => ["2", 4]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => ["2", "4"]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => [2, "4"]}) == 0.5
 
-      assert JsonLogicExp.resolve(%{"/" => ["1", 1]}) == 1
-      assert JsonLogicExp.resolve(%{"/" => ["1", "1"]}) == 1
-      assert JsonLogicExp.resolve(%{"/" => [1, "1"]}) == 1
+      assert JsonLogicXL.resolve(%{"/" => ["1", 1]}) == 1
+      assert JsonLogicXL.resolve(%{"/" => ["1", "1"]}) == 1
+      assert JsonLogicXL.resolve(%{"/" => [1, "1"]}) == 1
     end
 
     test "float division" do
-      assert JsonLogicExp.resolve(%{"/" => [2.0, 4.0]}) == 0.5
-      assert JsonLogicExp.resolve(%{"/" => ["2.0", 4.0]}) == 0.5
-      assert JsonLogicExp.resolve(%{"/" => ["2.0", "4.0"]}) == 0.5
-      assert JsonLogicExp.resolve(%{"/" => [2.0, "4.0"]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => [2.0, 4.0]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => ["2.0", 4.0]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => ["2.0", "4.0"]}) == 0.5
+      assert JsonLogicXL.resolve(%{"/" => [2.0, "4.0"]}) == 0.5
     end
 
     test "decimal division" do
@@ -814,18 +814,18 @@ defmodule JsonLogicExpTest do
       for left <- twos, right <- twos do
         assert_approx_eq(
           Decimal.new("1.0"),
-          JsonLogicExp.resolve(%{"/" => [left, right]})
+          JsonLogicXL.resolve(%{"/" => [left, right]})
         )
       end
 
-      assert JsonLogicExp.resolve(%{"/" => ["1", "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => [1, "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => [1.0, "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => ["1.0", "foo"]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => ["foo", "1"]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => ["foo", 1]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => ["foo", 1.0]}) == nil
-      assert JsonLogicExp.resolve(%{"/" => ["foo", "1.0"]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => ["1", "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => [1, "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => [1.0, "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => ["1.0", "foo"]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => ["foo", "1"]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => ["foo", 1]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => ["foo", 1.0]}) == nil
+      assert JsonLogicXL.resolve(%{"/" => ["foo", "1.0"]}) == nil
     end
   end
 
@@ -835,7 +835,7 @@ defmodule JsonLogicExpTest do
       twos = [2, 2.0, "2", "2.0", Decimal.new("2.0")]
 
       for left <- ones, right <- twos do
-        assert_approx_eq(1.0, JsonLogicExp.resolve(%{"%" => [left, right]}))
+        assert_approx_eq(1.0, JsonLogicXL.resolve(%{"%" => [left, right]}))
       end
     end
   end
@@ -844,11 +844,11 @@ defmodule JsonLogicExpTest do
     test "comparison with variables" do
       logic = %{">" => [%{"var" => "quantity"}, 25]}
       data = %{"quantity" => 1}
-      assert JsonLogicExp.resolve(logic, data) == false
+      assert JsonLogicXL.resolve(logic, data) == false
 
       logic = %{">" => [%{"var" => "quantity"}, 25]}
       data = %{"abc" => 1}
-      assert JsonLogicExp.resolve(logic, data) == false
+      assert JsonLogicXL.resolve(logic, data) == false
     end
 
     test "integer, float, and decimal comparisons" do
@@ -856,38 +856,38 @@ defmodule JsonLogicExpTest do
       twos = [Decimal.new("2.0"), "2.0", "2", 2.0, 2]
 
       for left <- ones, right <- ones do
-        refute JsonLogicExp.resolve(%{">" => [left, right]})
+        refute JsonLogicXL.resolve(%{">" => [left, right]})
       end
 
       for left <- twos, right <- ones do
-        assert JsonLogicExp.resolve(%{">" => [left, right]})
+        assert JsonLogicXL.resolve(%{">" => [left, right]})
       end
 
       for left <- ones, right <- twos do
-        refute JsonLogicExp.resolve(%{">" => [left, right]})
+        refute JsonLogicXL.resolve(%{">" => [left, right]})
       end
 
       for left <- ones, right <- ones do
         logic = %{">" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- twos, right <- ones do
         logic = %{">" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- ones, right <- twos do
         logic = %{">" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
     end
   end
 
   describe ">=" do
     test "number compared to non numeric string" do
-      refute JsonLogicExp.resolve(%{">=" => [1, "foo"]})
-      refute JsonLogicExp.resolve(%{">=" => ["foo", 1]})
+      refute JsonLogicXL.resolve(%{">=" => [1, "foo"]})
+      refute JsonLogicXL.resolve(%{">=" => ["foo", 1]})
     end
 
     test "integer, float, and decimal comparisons" do
@@ -895,30 +895,30 @@ defmodule JsonLogicExpTest do
       twos = [Decimal.new("2.0"), "2.0", "2", 2.0, 2]
 
       for left <- ones, right <- ones do
-        assert JsonLogicExp.resolve(%{">=" => [left, right]})
+        assert JsonLogicXL.resolve(%{">=" => [left, right]})
       end
 
       for left <- twos, right <- ones do
-        assert JsonLogicExp.resolve(%{">=" => [left, right]})
+        assert JsonLogicXL.resolve(%{">=" => [left, right]})
       end
 
       for left <- ones, right <- twos do
-        refute JsonLogicExp.resolve(%{">=" => [left, right]})
+        refute JsonLogicXL.resolve(%{">=" => [left, right]})
       end
 
       for left <- ones, right <- ones do
         logic = %{">=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- twos, right <- ones do
         logic = %{">=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- ones, right <- twos do
         logic = %{">=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
     end
   end
@@ -929,30 +929,30 @@ defmodule JsonLogicExpTest do
       twos = [Decimal.new("2.0"), "2.0", "2", 2.0, 2]
 
       for left <- ones, right <- ones do
-        refute JsonLogicExp.resolve(%{"<" => [left, right]})
+        refute JsonLogicXL.resolve(%{"<" => [left, right]})
       end
 
       for left <- twos, right <- ones do
-        refute JsonLogicExp.resolve(%{"<" => [left, right]})
+        refute JsonLogicXL.resolve(%{"<" => [left, right]})
       end
 
       for left <- ones, right <- twos do
-        assert JsonLogicExp.resolve(%{"<" => [left, right]})
+        assert JsonLogicXL.resolve(%{"<" => [left, right]})
       end
 
       for left <- ones, right <- ones do
         logic = %{"<" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- twos, right <- ones do
         logic = %{"<" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- ones, right <- twos do
         logic = %{"<" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
     end
   end
@@ -963,47 +963,47 @@ defmodule JsonLogicExpTest do
       twos = [Decimal.new("2.0"), "2.0", "2", 2.0, 2]
 
       for left <- ones, right <- ones do
-        assert JsonLogicExp.resolve(%{"<=" => [left, right]})
+        assert JsonLogicXL.resolve(%{"<=" => [left, right]})
       end
 
       for left <- twos, right <- ones do
-        refute JsonLogicExp.resolve(%{"<=" => [left, right]})
+        refute JsonLogicXL.resolve(%{"<=" => [left, right]})
       end
 
       for left <- ones, right <- twos do
-        assert JsonLogicExp.resolve(%{"<=" => [left, right]})
+        assert JsonLogicXL.resolve(%{"<=" => [left, right]})
       end
 
       for left <- ones, right <- ones do
         logic = %{"<=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- twos, right <- ones do
         logic = %{"<=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        refute JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        refute JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
 
       for left <- ones, right <- twos do
         logic = %{"<=" => [%{"var" => "left"}, %{"var" => "right"}]}
-        assert JsonLogicExp.resolve(logic, %{"left" => left, "right" => right})
+        assert JsonLogicXL.resolve(logic, %{"left" => left, "right" => right})
       end
     end
   end
 
   describe "between" do
     test "exclusive" do
-      assert JsonLogicExp.resolve(%{"<" => [1, 2, 3]})
-      refute JsonLogicExp.resolve(%{"<" => [1, 1, 3]})
-      refute JsonLogicExp.resolve(%{"<" => [1, 3, 3]})
-      refute JsonLogicExp.resolve(%{"<" => [1, 4, 3]})
+      assert JsonLogicXL.resolve(%{"<" => [1, 2, 3]})
+      refute JsonLogicXL.resolve(%{"<" => [1, 1, 3]})
+      refute JsonLogicXL.resolve(%{"<" => [1, 3, 3]})
+      refute JsonLogicXL.resolve(%{"<" => [1, 4, 3]})
     end
 
     test "inclusive" do
-      assert JsonLogicExp.resolve(%{"<=" => [1, 2, 3]})
-      assert JsonLogicExp.resolve(%{"<=" => [1, 1, 3]})
-      assert JsonLogicExp.resolve(%{"<=" => [1, 3, 3]})
-      refute JsonLogicExp.resolve(%{"<=" => [1, 4, 3]})
+      assert JsonLogicXL.resolve(%{"<=" => [1, 2, 3]})
+      assert JsonLogicXL.resolve(%{"<=" => [1, 1, 3]})
+      assert JsonLogicXL.resolve(%{"<=" => [1, 3, 3]})
+      refute JsonLogicXL.resolve(%{"<=" => [1, 4, 3]})
     end
   end
 
@@ -1012,7 +1012,7 @@ defmodule JsonLogicExpTest do
       logic = %{"map" => [%{"var" => "integers"}, %{"*" => [%{"var" => ""}, 2]}]}
       data = %{"integers" => [1, 2, 3, 4, 5]}
 
-      assert JsonLogicExp.resolve(logic, data) == [2, 4, 6, 8, 10]
+      assert JsonLogicXL.resolve(logic, data) == [2, 4, 6, 8, 10]
     end
   end
 
@@ -1021,14 +1021,14 @@ defmodule JsonLogicExpTest do
       logic = %{"filter" => [%{"var" => "integers"}, %{">" => [%{"var" => ""}, 2]}]}
       data = %{"integers" => [1, 2, 3, 4, 5]}
 
-      assert JsonLogicExp.resolve(logic, data) == [3, 4, 5]
+      assert JsonLogicXL.resolve(logic, data) == [3, 4, 5]
     end
 
     test "returns filtered objects" do
       logic = %{"filter" => [%{"var" => "objects"}, %{"==" => [%{"var" => "uid"}, "A"]}]}
       data = %{"objects" => [%{"uid" => "A"}, %{"uid" => "B"}]}
 
-      assert JsonLogicExp.resolve(logic, data) == [%{"uid" => "A"}]
+      assert JsonLogicXL.resolve(logic, data) == [%{"uid" => "A"}]
     end
   end
 
@@ -1044,7 +1044,7 @@ defmodule JsonLogicExpTest do
 
       data = %{"integers" => [1, 2, 3]}
 
-      assert JsonLogicExp.resolve(logic, data) == 6
+      assert JsonLogicXL.resolve(logic, data) == 6
     end
   end
 
@@ -1053,7 +1053,7 @@ defmodule JsonLogicExpTest do
       logic = %{"in" => [%{"var" => "find"}, %{"var" => "from"}]}
       data = %{"find" => "sub", "from" => "substring"}
 
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
     end
 
     test "returns true from var list" do
@@ -1064,7 +1064,7 @@ defmodule JsonLogicExpTest do
         "from" => ["sub", "string"]
       }
 
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
     end
 
     test "returns false from nil" do
@@ -1075,7 +1075,7 @@ defmodule JsonLogicExpTest do
         "from" => nil
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
     end
 
     test "returns false from var list" do
@@ -1086,13 +1086,13 @@ defmodule JsonLogicExpTest do
         "from" => ["A", "B"]
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
     end
 
     test "Bart is found in the list" do
       logic = %{"in" => ["Bart", ["Bart", "Homer", "Lisa", "Marge", "Maggie"]]}
 
-      assert JsonLogicExp.resolve(logic)
+      assert JsonLogicXL.resolve(logic)
     end
 
     test "Milhouse is not found in the list" do
@@ -1100,66 +1100,66 @@ defmodule JsonLogicExpTest do
         "in" => ["Milhouse", ["Bart", "Homer", "Lisa", "Marge", "Maggie"]]
       }
 
-      refute JsonLogicExp.resolve(logic)
+      refute JsonLogicXL.resolve(logic)
     end
 
     test "finding a string in a string" do
-      assert JsonLogicExp.resolve(%{"in" => ["Spring", "Springfield"]})
-      refute JsonLogicExp.resolve(%{"in" => ["i", "team"]})
+      assert JsonLogicXL.resolve(%{"in" => ["Spring", "Springfield"]})
+      refute JsonLogicXL.resolve(%{"in" => ["i", "team"]})
     end
 
     test "raises on non-enumerable list" do
       assert_raise(ArgumentError, fn ->
         logic = %{"in" => [%{"var" => "users.id"}, 1]}
-        JsonLogicExp.resolve(logic, nil)
+        JsonLogicXL.resolve(logic, nil)
       end)
     end
   end
 
   describe "merge" do
     test "empty array" do
-      assert JsonLogicExp.resolve(%{"merge" => []}) == []
+      assert JsonLogicXL.resolve(%{"merge" => []}) == []
     end
 
     test "flattens arrays" do
-      assert JsonLogicExp.resolve(%{"merge" => [[1]]}) == [1]
-      assert JsonLogicExp.resolve(%{"merge" => [[1], []]}) == [1]
-      assert JsonLogicExp.resolve(%{"merge" => [[1], [2]]}) == [1, 2]
-      assert JsonLogicExp.resolve(%{"merge" => [[1], [2], [3]]}) == [1, 2, 3]
-      assert JsonLogicExp.resolve(%{"merge" => [[1, 2], [3]]}) == [1, 2, 3]
-      assert JsonLogicExp.resolve(%{"merge" => [[1], [2, 3]]}) == [1, 2, 3]
-      assert JsonLogicExp.resolve(%{"merge" => [[1, 2], [3, 4]]}) == [1, 2, 3, 4]
+      assert JsonLogicXL.resolve(%{"merge" => [[1]]}) == [1]
+      assert JsonLogicXL.resolve(%{"merge" => [[1], []]}) == [1]
+      assert JsonLogicXL.resolve(%{"merge" => [[1], [2]]}) == [1, 2]
+      assert JsonLogicXL.resolve(%{"merge" => [[1], [2], [3]]}) == [1, 2, 3]
+      assert JsonLogicXL.resolve(%{"merge" => [[1, 2], [3]]}) == [1, 2, 3]
+      assert JsonLogicXL.resolve(%{"merge" => [[1], [2, 3]]}) == [1, 2, 3]
+      assert JsonLogicXL.resolve(%{"merge" => [[1, 2], [3, 4]]}) == [1, 2, 3, 4]
     end
 
     test "non array argumnets" do
-      assert JsonLogicExp.resolve(%{"merge" => nil}) == [nil]
-      assert JsonLogicExp.resolve(%{"merge" => 1}, nil) == [1]
-      assert JsonLogicExp.resolve(%{"merge" => [1, 2]}) == [1, 2]
-      assert JsonLogicExp.resolve(%{"merge" => [1, [2]]}) == [1, 2]
+      assert JsonLogicXL.resolve(%{"merge" => nil}) == [nil]
+      assert JsonLogicXL.resolve(%{"merge" => 1}, nil) == [1]
+      assert JsonLogicXL.resolve(%{"merge" => [1, 2]}) == [1, 2]
+      assert JsonLogicXL.resolve(%{"merge" => [1, [2]]}) == [1, 2]
     end
   end
 
   describe "or" do
     test "specification" do
-      assert JsonLogicExp.resolve(%{"or" => [true, true]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [false, true]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [true, false]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [false, false]}) == false
+      assert JsonLogicXL.resolve(%{"or" => [true, true]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [false, true]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [true, false]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [false, false]}) == false
 
-      assert JsonLogicExp.resolve(%{"or" => [true, nil]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [nil, nil]}) == nil
-      assert JsonLogicExp.resolve(%{"or" => [nil, 1]}) == 1
-      assert JsonLogicExp.resolve(%{"or" => [nil, 3]}) == 3
-      assert JsonLogicExp.resolve(%{"or" => [1, 3]}) == 1
-      assert JsonLogicExp.resolve(%{"or" => [true, 3]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [true, nil]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [nil, nil]}) == nil
+      assert JsonLogicXL.resolve(%{"or" => [nil, 1]}) == 1
+      assert JsonLogicXL.resolve(%{"or" => [nil, 3]}) == 3
+      assert JsonLogicXL.resolve(%{"or" => [1, 3]}) == 1
+      assert JsonLogicXL.resolve(%{"or" => [true, 3]}) == true
 
-      assert JsonLogicExp.resolve(%{"or" => [true, true, true]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [false, true, true]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [true, false, true]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [true, false, false]}) == true
-      assert JsonLogicExp.resolve(%{"or" => [false, false, false]}) == false
+      assert JsonLogicXL.resolve(%{"or" => [true, true, true]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [false, true, true]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [true, false, true]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [true, false, false]}) == true
+      assert JsonLogicXL.resolve(%{"or" => [false, false, false]}) == false
 
-      assert JsonLogicExp.resolve(%{"or" => [false, false, false, 1]}) == 1
+      assert JsonLogicXL.resolve(%{"or" => [false, false, false, 1]}) == 1
     end
   end
 
@@ -1172,85 +1172,85 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic) == true
+      assert JsonLogicXL.resolve(logic) == true
     end
 
     test "specification" do
-      assert JsonLogicExp.resolve(%{"and" => [true]}) == true
-      assert JsonLogicExp.resolve(%{"and" => [false]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [true]}) == true
+      assert JsonLogicXL.resolve(%{"and" => [false]}) == false
 
-      assert JsonLogicExp.resolve(%{"and" => [true, true]})
-      assert JsonLogicExp.resolve(%{"and" => [false, true]}) == false
-      assert JsonLogicExp.resolve(%{"and" => [true, false]}) == false
-      assert JsonLogicExp.resolve(%{"and" => [false, false]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [true, true]})
+      assert JsonLogicXL.resolve(%{"and" => [false, true]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [true, false]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [false, false]}) == false
 
-      assert JsonLogicExp.resolve(%{"and" => [true, true, true]}) == true
-      assert JsonLogicExp.resolve(%{"and" => [true, true, false]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [true, true, true]}) == true
+      assert JsonLogicXL.resolve(%{"and" => [true, true, false]}) == false
 
-      assert JsonLogicExp.resolve(%{"and" => [1, 3]}) == 3
-      assert JsonLogicExp.resolve(%{"and" => [1, 2, 3]}) == 3
-      assert JsonLogicExp.resolve(%{"and" => [1, false]}) == false
-      assert JsonLogicExp.resolve(%{"and" => [false, 1]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [1, 3]}) == 3
+      assert JsonLogicXL.resolve(%{"and" => [1, 2, 3]}) == 3
+      assert JsonLogicXL.resolve(%{"and" => [1, false]}) == false
+      assert JsonLogicXL.resolve(%{"and" => [false, 1]}) == false
     end
   end
 
   describe "?:" do
     test "specification" do
-      assert JsonLogicExp.resolve(%{"?:" => [true, 1, 2]}) == 1
-      assert JsonLogicExp.resolve(%{"?:" => [false, 1, 2]}) == 2
+      assert JsonLogicXL.resolve(%{"?:" => [true, 1, 2]}) == 1
+      assert JsonLogicXL.resolve(%{"?:" => [false, 1, 2]}) == 2
     end
   end
 
   describe "cat" do
     test "specification" do
-      assert JsonLogicExp.resolve(%{"cat" => "ice"}) == "ice"
-      assert JsonLogicExp.resolve(%{"cat" => ["ice"]}) == "ice"
-      assert JsonLogicExp.resolve(%{"cat" => ["ice", "cream"]}) == "icecream"
-      assert JsonLogicExp.resolve(%{"cat" => [1, 2]}) == "12"
-      assert JsonLogicExp.resolve(%{"cat" => [1.0, 2.0]}) == "1.02.0"
-      assert JsonLogicExp.resolve(%{"cat" => [1.1, 2.1]}) == "1.12.1"
-      assert JsonLogicExp.resolve(%{"cat" => ["Robocop", 2]}) == "Robocop2"
-      assert JsonLogicExp.resolve(%{"cat" => ["a", nil, "b"]}) == "ab"
+      assert JsonLogicXL.resolve(%{"cat" => "ice"}) == "ice"
+      assert JsonLogicXL.resolve(%{"cat" => ["ice"]}) == "ice"
+      assert JsonLogicXL.resolve(%{"cat" => ["ice", "cream"]}) == "icecream"
+      assert JsonLogicXL.resolve(%{"cat" => [1, 2]}) == "12"
+      assert JsonLogicXL.resolve(%{"cat" => [1.0, 2.0]}) == "1.02.0"
+      assert JsonLogicXL.resolve(%{"cat" => [1.1, 2.1]}) == "1.12.1"
+      assert JsonLogicXL.resolve(%{"cat" => ["Robocop", 2]}) == "Robocop2"
+      assert JsonLogicXL.resolve(%{"cat" => ["a", nil, "b"]}) == "ab"
 
       logic = %{"cat" => ["we all scream for ", "ice", "cream"]}
-      assert JsonLogicExp.resolve(logic) == "we all scream for icecream"
+      assert JsonLogicXL.resolve(logic) == "we all scream for icecream"
 
       logic = %{"cat" => [%{"var" => "x"}, %{"var" => "y"}]}
       data = %{"x" => "foo", "y" => "bar"}
-      assert JsonLogicExp.resolve(logic, data) == "foobar"
+      assert JsonLogicXL.resolve(logic, data) == "foobar"
     end
   end
 
   describe "substr" do
     test "substr with only start" do
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", 4]}) == "logic"
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", -5]}) == "logic"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsonlögic", -5]}) == "lögic"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsönlögic", -5]}) == "lögic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", 4]}) == "logic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", -5]}) == "logic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlögic", -5]}) == "lögic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsönlögic", -5]}) == "lögic"
 
-      assert JsonLogicExp.resolve(%{"substr" => ["", 4]}) == ""
-      assert JsonLogicExp.resolve(%{"substr" => ["", -4]}) == ""
+      assert JsonLogicXL.resolve(%{"substr" => ["", 4]}) == ""
+      assert JsonLogicXL.resolve(%{"substr" => ["", -4]}) == ""
 
-      assert JsonLogicExp.resolve(%{"substr" => ["Göödnight", 4]}) == "night"
-      assert JsonLogicExp.resolve(%{"substr" => ["Göödnight", 2]}) == "ödnight"
+      assert JsonLogicXL.resolve(%{"substr" => ["Göödnight", 4]}) == "night"
+      assert JsonLogicXL.resolve(%{"substr" => ["Göödnight", 2]}) == "ödnight"
     end
 
     test "substr with start and character count" do
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", 0, 1]}) == "j"
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", -1, 1]}) == "c"
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", 4, 5]}) == "logic"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsonlögic", 4, 5]}) == "lögic"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsönlögic", 4, 5]}) == "lögic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", 0, 1]}) == "j"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", -1, 1]}) == "c"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", 4, 5]}) == "logic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlögic", 4, 5]}) == "lögic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsönlögic", 4, 5]}) == "lögic"
 
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", -5, 5]}) == "logic"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsonlögic", -5, 5]}) == "lögic"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsönlögic", -5, 5]}) == "lögic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", -5, 5]}) == "logic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlögic", -5, 5]}) == "lögic"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsönlögic", -5, 5]}) == "lögic"
 
-      assert JsonLogicExp.resolve(%{"substr" => ["jsönlögic", -5, -2]}) == "lög"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsönlogic", -5, -2]}) == "log"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsönlögic", -5, -2]}) == "lög"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsönlogic", -5, -2]}) == "log"
 
-      assert JsonLogicExp.resolve(%{"substr" => ["JsonLogicExp", 1, -5]}) == "son"
-      assert JsonLogicExp.resolve(%{"substr" => ["jsönlogic", 1, -5]}) == "sön"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsonlogic", 1, -5]}) == "son"
+      assert JsonLogicXL.resolve(%{"substr" => ["jsönlogic", 1, -5]}) == "sön"
     end
   end
 
@@ -1258,97 +1258,97 @@ defmodule JsonLogicExpTest do
     test "using a variable" do
       logic = [1, %{"var" => "x"}, 3]
       data = %{"x" => 2}
-      assert JsonLogicExp.resolve(logic, data) == [1, 2, 3]
+      assert JsonLogicXL.resolve(logic, data) == [1, 2, 3]
     end
 
     test "using a variable in an if" do
       logic = %{"if" => [%{"var" => "x"}, %{"var" => "y"}, 99]}
       data = %{"x" => true, "y" => 2}
-      assert JsonLogicExp.resolve(logic, data) == 2
+      assert JsonLogicXL.resolve(logic, data) == 2
 
       logic = %{"if" => [%{"var" => "x"}, [%{"var" => "y"}], [99]]}
       data = %{"x" => true, "y" => 2}
-      assert JsonLogicExp.resolve(logic, data) == [2]
+      assert JsonLogicXL.resolve(logic, data) == [2]
 
       logic = %{"if" => [%{"var" => "x"}, %{"var" => "y"}, 99]}
       data = %{"x" => false, "y" => 2}
-      assert JsonLogicExp.resolve(logic, data) == 99
+      assert JsonLogicXL.resolve(logic, data) == 99
 
       logic = %{"if" => [%{"var" => "x"}, [%{"var" => "y"}], [99]]}
       data = %{"x" => false, "y" => 2}
-      assert JsonLogicExp.resolve(logic, data) == [99]
+      assert JsonLogicXL.resolve(logic, data) == [99]
     end
 
     test "compount test" do
       logic = %{"and" => [%{">" => [3, 1]}, true]}
-      assert JsonLogicExp.resolve(logic, %{})
+      assert JsonLogicXL.resolve(logic, %{})
 
       logic = %{"and" => [%{">" => [3, 1]}, false]}
-      refute JsonLogicExp.resolve(logic, %{})
+      refute JsonLogicXL.resolve(logic, %{})
 
       logic = %{"and" => [%{">" => [3, 1]}, %{"!" => true}]}
-      refute JsonLogicExp.resolve(logic, %{})
+      refute JsonLogicXL.resolve(logic, %{})
 
       logic = %{"and" => [%{">" => [3, 1]}, %{"<" => [1, 3]}]}
-      assert JsonLogicExp.resolve(logic, %{})
+      assert JsonLogicXL.resolve(logic, %{})
 
       logic = %{"?:" => [%{">" => [3, 1]}, "visible", "hidden"]}
-      assert JsonLogicExp.resolve(logic, %{}) == "visible"
+      assert JsonLogicXL.resolve(logic, %{}) == "visible"
     end
 
     test "data driven" do
       logic = %{"var" => ["a"]}
       data = %{"a" => 1}
-      assert JsonLogicExp.resolve(logic, data) == 1
+      assert JsonLogicXL.resolve(logic, data) == 1
 
       logic = %{"var" => ["b"]}
       data = %{"a" => 1}
-      assert JsonLogicExp.resolve(logic, data) == nil
+      assert JsonLogicXL.resolve(logic, data) == nil
 
       logic = %{"var" => ["a"]}
-      assert JsonLogicExp.resolve(logic, nil) == nil
+      assert JsonLogicXL.resolve(logic, nil) == nil
 
       logic = %{"var" => "a"}
       data = %{"a" => 1}
-      assert JsonLogicExp.resolve(logic, data) == 1
+      assert JsonLogicXL.resolve(logic, data) == 1
 
       logic = %{"var" => "b"}
       data = %{"a" => 1}
-      assert JsonLogicExp.resolve(logic, data) == nil
+      assert JsonLogicXL.resolve(logic, data) == nil
 
       logic = %{"var" => "a"}
-      assert JsonLogicExp.resolve(logic, nil) == nil
+      assert JsonLogicXL.resolve(logic, nil) == nil
 
       logic = %{"var" => ["a", 1]}
-      assert JsonLogicExp.resolve(logic, nil) == 1
+      assert JsonLogicXL.resolve(logic, nil) == 1
 
       logic = %{"var" => ["b", 2]}
       data = %{"a" => 1}
-      assert JsonLogicExp.resolve(logic, data) == 2
+      assert JsonLogicXL.resolve(logic, data) == 2
 
       logic = %{"var" => "a.b"}
       data = %{"a" => %{"b" => "c"}}
-      assert JsonLogicExp.resolve(logic, data) == "c"
+      assert JsonLogicXL.resolve(logic, data) == "c"
 
       logic = %{"var" => "a.q"}
       data = %{"a" => %{"b" => "c"}}
-      assert JsonLogicExp.resolve(logic, data) == nil
+      assert JsonLogicXL.resolve(logic, data) == nil
 
       logic = %{"var" => ["a.q", 9]}
       data = %{"a" => %{"b" => "c"}}
-      assert JsonLogicExp.resolve(logic, data) == 9
+      assert JsonLogicXL.resolve(logic, data) == 9
 
       logic = %{"var" => 1}
       data = ["apple", "banana"]
-      assert JsonLogicExp.resolve(logic, data) == "banana"
+      assert JsonLogicXL.resolve(logic, data) == "banana"
 
       logic = %{"var" => "1"}
       data = ["apple", "banana"]
-      assert JsonLogicExp.resolve(logic, data) == "banana"
+      assert JsonLogicXL.resolve(logic, data) == "banana"
 
       logic = %{"var" => "1.1"}
       data = ["apple", ["banana", "beer"]]
-      assert JsonLogicExp.resolve(logic, data) == "beer"
+      assert JsonLogicXL.resolve(logic, data) == "beer"
 
       logic = %{
         "and" => [
@@ -1358,7 +1358,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"pie" => %{"filling" => "apple"}, "temp" => 100}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{
         "var" => [
@@ -1373,89 +1373,89 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"pie" => %{"eta" => "60s", "filling" => "apple"}, "temp" => 100}
-      assert JsonLogicExp.resolve(logic, data) == "apple"
+      assert JsonLogicXL.resolve(logic, data) == "apple"
 
       logic = %{"in" => [%{"var" => "filling"}, ["apple", "cherry"]]}
       data = %{"filling" => "apple"}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"var" => "a.b.c"}
-      assert JsonLogicExp.resolve(logic, nil) == nil
+      assert JsonLogicXL.resolve(logic, nil) == nil
 
       logic = %{"var" => "a.b.c"}
       data = %{"a" => nil}
-      assert JsonLogicExp.resolve(logic, data) == nil
+      assert JsonLogicXL.resolve(logic, data) == nil
 
       logic = %{"var" => "a.b.c"}
       data = %{"a" => %{"b" => nil}}
-      assert JsonLogicExp.resolve(logic, data) == nil
+      assert JsonLogicXL.resolve(logic, data) == nil
 
       logic = %{"var" => ""}
-      assert JsonLogicExp.resolve(logic, 1) == 1
+      assert JsonLogicXL.resolve(logic, 1) == 1
 
       logic = %{"var" => nil}
-      assert JsonLogicExp.resolve(logic, 1) == 1
+      assert JsonLogicXL.resolve(logic, 1) == 1
 
       logic = %{"var" => []}
-      assert JsonLogicExp.resolve(logic, 1) == 1
+      assert JsonLogicXL.resolve(logic, 1) == 1
     end
   end
 
   describe "missing" do
     test "specification" do
       logic = %{"missing" => []}
-      assert JsonLogicExp.resolve(logic, nil) == []
+      assert JsonLogicXL.resolve(logic, nil) == []
 
       logic = %{"missing" => ["a"]}
-      assert JsonLogicExp.resolve(logic, nil) == ["a"]
+      assert JsonLogicXL.resolve(logic, nil) == ["a"]
 
       logic = %{"missing" => "a"}
-      assert JsonLogicExp.resolve(logic, nil) == ["a"]
+      assert JsonLogicXL.resolve(logic, nil) == ["a"]
 
       logic = %{"missing" => "a"}
       data = %{"a" => "apple"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing" => ["a"]}
       data = %{"a" => "apple"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing" => ["a", "b"]}
       data = %{"a" => "apple"}
-      assert JsonLogicExp.resolve(logic, data) == ["b"]
+      assert JsonLogicXL.resolve(logic, data) == ["b"]
 
       logic = %{"missing" => ["a", "b"]}
       data = %{"b" => "banana"}
-      assert JsonLogicExp.resolve(logic, data) == ["a"]
+      assert JsonLogicXL.resolve(logic, data) == ["a"]
 
       logic = %{"missing" => ["a", "b"]}
       data = %{"a" => "apple", "b" => "banana"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing" => ["a", "b"]}
-      assert JsonLogicExp.resolve(logic, %{}) == ["a", "b"]
+      assert JsonLogicXL.resolve(logic, %{}) == ["a", "b"]
 
       logic = %{"missing" => ["a", "b"]}
-      assert JsonLogicExp.resolve(logic, nil) == ["a", "b"]
+      assert JsonLogicXL.resolve(logic, nil) == ["a", "b"]
 
       logic = %{"missing" => ["a.b"]}
-      assert JsonLogicExp.resolve(logic, nil) == ["a.b"]
+      assert JsonLogicXL.resolve(logic, nil) == ["a.b"]
 
       logic = %{"missing" => ["a.b"]}
       data = %{"a" => "apple"}
-      assert JsonLogicExp.resolve(logic, data) == ["a.b"]
+      assert JsonLogicXL.resolve(logic, data) == ["a.b"]
 
       logic = %{"missing" => ["a.b"]}
       data = %{"a" => %{"c" => "apple cake"}}
-      assert JsonLogicExp.resolve(logic, data) == ["a.b"]
+      assert JsonLogicXL.resolve(logic, data) == ["a.b"]
 
       logic = %{"missing" => ["a.b"]}
       data = %{"a" => %{"b" => "apple brownie"}}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing" => ["a.b", "a.c"]}
       data = %{"a" => %{"b" => "apple brownie"}}
-      assert JsonLogicExp.resolve(logic, data) == ["a.c"]
+      assert JsonLogicXL.resolve(logic, data) == ["a.c"]
     end
   end
 
@@ -1463,49 +1463,49 @@ defmodule JsonLogicExpTest do
     test "specification" do
       logic = %{"missing_some" => [1, ["a", "b"]]}
       data = %{"a" => "apple"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing_some" => [1, ["a", "b"]]}
       data = %{"b" => "banana"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing_some" => [1, ["a", "b"]]}
       data = %{"a" => "apple", "b" => "banana"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing_some" => [1, ["a", "b"]]}
       data = %{"c" => "carrot"}
-      assert JsonLogicExp.resolve(logic, data) == ["a", "b"]
+      assert JsonLogicXL.resolve(logic, data) == ["a", "b"]
 
       logic = %{"missing_some" => [2, ["a", "b", "c"]]}
       data = %{"a" => "apple", "b" => "banana"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing_some" => [2, ["a", "b", "c"]]}
       data = %{"a" => "apple", "c" => "carrot"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing_some" => [2, ["a", "b", "c"]]}
       data = %{"a" => "apple", "b" => "banana", "c" => "carrot"}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"missing_some" => [2, ["a", "b", "c"]]}
       data = %{"a" => "apple", "d" => "durian"}
-      assert JsonLogicExp.resolve(logic, data) == ["b", "c"]
+      assert JsonLogicXL.resolve(logic, data) == ["b", "c"]
 
       logic = %{"missing_some" => [2, ["a", "b", "c"]]}
       data = %{"d" => "durian", "e" => "eggplant"}
-      assert JsonLogicExp.resolve(logic, data) == ["a", "b", "c"]
+      assert JsonLogicXL.resolve(logic, data) == ["a", "b", "c"]
     end
 
-    test "missing and If are friends, because empty arrays are falsey in JsonLogicExp" do
+    test "missing and If are friends, because empty arrays are falsey in JsonLogicXL" do
       logic = %{"if" => [%{"missing" => "a"}, "missed it", "found it"]}
       data = %{"a" => "apple"}
-      assert JsonLogicExp.resolve(logic, data) == "found it"
+      assert JsonLogicXL.resolve(logic, data) == "found it"
 
       logic = %{"if" => [%{"missing" => "a"}, "missed it", "found it"]}
       data = %{"b" => "banana"}
-      assert JsonLogicExp.resolve(logic, data) == "missed it"
+      assert JsonLogicXL.resolve(logic, data) == "missed it"
     end
 
     test "missing, merge, and if are friends. VIN is always required, APR is only required if financing is true." do
@@ -1516,7 +1516,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"financing" => true}
-      assert JsonLogicExp.resolve(logic, data) == ["vin", "apr"]
+      assert JsonLogicXL.resolve(logic, data) == ["vin", "apr"]
 
       logic = %{
         "missing" => %{
@@ -1525,7 +1525,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"financing" => false}
-      assert JsonLogicExp.resolve(logic, data) == ["vin"]
+      assert JsonLogicXL.resolve(logic, data) == ["vin"]
     end
   end
 
@@ -1533,26 +1533,26 @@ defmodule JsonLogicExpTest do
     test "filter, map, all, none, and some" do
       logic = %{"filter" => [%{"var" => "integers"}, true]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data) == [1, 2, 3]
+      assert JsonLogicXL.resolve(logic, data) == [1, 2, 3]
 
       logic = %{"filter" => [%{"var" => "integers"}, false]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data) == []
+      assert JsonLogicXL.resolve(logic, data) == []
 
       logic = %{"filter" => [%{"var" => "integers"}, %{">=" => [%{"var" => ""}, 2]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data) == [2, 3]
+      assert JsonLogicXL.resolve(logic, data) == [2, 3]
 
       logic = %{"filter" => [%{"var" => "integers"}, %{"%" => [%{"var" => ""}, 2]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data) == [1, 3]
+      assert JsonLogicXL.resolve(logic, data) == [1, 3]
 
       logic = %{"map" => [%{"var" => "integers"}, %{"*" => [%{"var" => ""}, 2]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data) == [2, 4, 6]
+      assert JsonLogicXL.resolve(logic, data) == [2, 4, 6]
 
       logic = %{"map" => [%{"var" => "integers"}, %{"*" => [%{"var" => ""}, 2]}]}
-      assert JsonLogicExp.resolve(logic, nil) == []
+      assert JsonLogicXL.resolve(logic, nil) == []
 
       logic = %{"map" => [%{"var" => "desserts"}, %{"var" => "qty"}]}
 
@@ -1564,7 +1564,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic, data) == [1, 2, 3]
+      assert JsonLogicXL.resolve(logic, data) == [1, 2, 3]
 
       logic = %{
         "reduce" => [
@@ -1575,7 +1575,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"integers" => [1, 2, 3, 4]}
-      assert JsonLogicExp.resolve(logic, data) == 10
+      assert JsonLogicXL.resolve(logic, data) == 10
 
       logic = %{
         "reduce" => [
@@ -1586,7 +1586,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = nil
-      assert JsonLogicExp.resolve(logic, data) == 0
+      assert JsonLogicXL.resolve(logic, data) == 0
 
       logic = %{
         "reduce" => [
@@ -1597,7 +1597,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"integers" => [1, 2, 3, 4]}
-      assert JsonLogicExp.resolve(logic, data) == 24
+      assert JsonLogicXL.resolve(logic, data) == 24
 
       logic = %{
         "reduce" => [
@@ -1608,7 +1608,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"integers" => [1, 2, 3, 4]}
-      assert JsonLogicExp.resolve(logic, data) == 0
+      assert JsonLogicXL.resolve(logic, data) == 0
 
       logic = %{
         "reduce" => [
@@ -1626,23 +1626,23 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic, data) == 6
+      assert JsonLogicXL.resolve(logic, data) == 6
 
       logic = %{"all" => [%{"var" => "integers"}, %{">=" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "integers"}, %{"==" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "integers"}, %{"<" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "integers"}, %{"<" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => []}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "items"}, %{">=" => [%{"var" => "qty"}, 1]}]}
 
@@ -1653,7 +1653,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "items"}, %{">" => [%{"var" => "qty"}, 1]}]}
 
@@ -1664,7 +1664,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "items"}, %{"<" => [%{"var" => "qty"}, 1]}]}
 
@@ -1675,27 +1675,27 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"all" => [%{"var" => "items"}, %{">=" => [%{"var" => "qty"}, 1]}]}
       data = %{"items" => []}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "integers"}, %{">=" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "integers"}, %{"==" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "integers"}, %{"<" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "integers"}, %{"<" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => []}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "items"}, %{">=" => [%{"var" => "qty"}, 1]}]}
 
@@ -1706,7 +1706,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "items"}, %{">" => [%{"var" => "qty"}, 1]}]}
 
@@ -1717,7 +1717,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "items"}, %{"<" => [%{"var" => "qty"}, 1]}]}
 
@@ -1728,27 +1728,27 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"none" => [%{"var" => "items"}, %{">=" => [%{"var" => "qty"}, 1]}]}
       data = %{"items" => []}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "integers"}, %{">=" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "integers"}, %{"==" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "integers"}, %{"<" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => [1, 2, 3]}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "integers"}, %{"<" => [%{"var" => ""}, 1]}]}
       data = %{"integers" => []}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "items"}, %{">=" => [%{"var" => "qty"}, 1]}]}
 
@@ -1759,7 +1759,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "items"}, %{">" => [%{"var" => "qty"}, 1]}]}
 
@@ -1770,7 +1770,7 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "items"}, %{"<" => [%{"var" => "qty"}, 1]}]}
 
@@ -1781,51 +1781,51 @@ defmodule JsonLogicExpTest do
         ]
       }
 
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"some" => [%{"var" => "items"}, %{">=" => [%{"var" => "qty"}, 1]}]}
       data = %{"items" => []}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
     end
   end
 
   describe "data does not contain the param specified in conditions" do
     test "cannot compare nil" do
-      assert JsonLogicExp.resolve(%{"==" => [nil, nil]})
-      assert JsonLogicExp.resolve(%{"<" => [nil, nil]})
-      assert JsonLogicExp.resolve(%{">" => [nil, nil]})
-      assert JsonLogicExp.resolve(%{"<=" => [nil, nil]})
-      assert JsonLogicExp.resolve(%{">=" => [nil, nil]})
+      assert JsonLogicXL.resolve(%{"==" => [nil, nil]})
+      assert JsonLogicXL.resolve(%{"<" => [nil, nil]})
+      assert JsonLogicXL.resolve(%{">" => [nil, nil]})
+      assert JsonLogicXL.resolve(%{"<=" => [nil, nil]})
+      assert JsonLogicXL.resolve(%{">=" => [nil, nil]})
 
       logic = %{"<=" => [%{"var" => "optional"}, nil]}
       data = %{"optional" => nil}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{">=" => [%{"var" => "optional"}, nil]}
       data = %{"optional" => nil}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       logic = %{"==" => [%{"var" => "optional"}, nil]}
       data = %{"optional" => nil}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
-      refute JsonLogicExp.resolve(%{">" => [5, nil]})
-      refute JsonLogicExp.resolve(%{">" => [nil, 5]})
-      refute JsonLogicExp.resolve(%{">=" => [5, nil]})
-      refute JsonLogicExp.resolve(%{">=" => [nil, 5]})
+      refute JsonLogicXL.resolve(%{">" => [5, nil]})
+      refute JsonLogicXL.resolve(%{">" => [nil, 5]})
+      refute JsonLogicXL.resolve(%{">=" => [5, nil]})
+      refute JsonLogicXL.resolve(%{">=" => [nil, 5]})
 
-      refute JsonLogicExp.resolve(%{"<" => [5, nil]})
-      refute JsonLogicExp.resolve(%{"<" => [nil, 5]})
-      refute JsonLogicExp.resolve(%{"<=" => [5, nil]})
-      refute JsonLogicExp.resolve(%{"<=" => [nil, 5]})
+      refute JsonLogicXL.resolve(%{"<" => [5, nil]})
+      refute JsonLogicXL.resolve(%{"<" => [nil, 5]})
+      refute JsonLogicXL.resolve(%{"<=" => [5, nil]})
+      refute JsonLogicXL.resolve(%{"<=" => [nil, 5]})
 
       logic = %{">" => [%{"var" => "quantity"}, 25]}
       data = %{"abc" => 1}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{"<" => [%{"var" => "quantity"}, 25]}
       data = %{"abc" => 1}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{
         "and" => [
@@ -1835,7 +1835,7 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"code" => "FUM", "occurence" => 15}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
 
       logic = %{
         "or" => [
@@ -1855,23 +1855,23 @@ defmodule JsonLogicExpTest do
       }
 
       data = %{"accessorial_service" => %{"code" => "WAT", "occurence" => 15}}
-      assert JsonLogicExp.resolve(logic, data)
+      assert JsonLogicXL.resolve(logic, data)
 
       data = %{"accessorial_service" => %{"code" => "FUM", "occurence" => 15}}
-      refute JsonLogicExp.resolve(logic, data)
+      refute JsonLogicXL.resolve(logic, data)
     end
   end
 
   describe "log" do
     test "that log is just a pass throug" do
-      assert JsonLogicExp.resolve(%{"log" => [1]}) == [1]
+      assert JsonLogicXL.resolve(%{"log" => [1]}) == [1]
     end
   end
 
   describe "unsupported operation" do
     test "raises exception" do
       assert_raise(ArgumentError, fn ->
-        JsonLogicExp.resolve(%{"doesnotexist" => 1})
+        JsonLogicXL.resolve(%{"doesnotexist" => 1})
       end)
     end
   end
@@ -1880,9 +1880,82 @@ defmodule JsonLogicExpTest do
     test "passes through the results" do
       # This is the expected result according to
       #
-      # https://JsonLogicExp.com/play.html
+      # https://JsonLogicXL.com/play.html
       logic = %{"-" => [1, 1], "+" => [1, 1]}
-      assert logic == JsonLogicExp.resolve(logic)
+      assert logic == JsonLogicXL.resolve(logic)
+    end
+  end
+
+  describe "xlookup" do
+    test "matches a string value" do
+      logic = %{
+        "xlookup" => [
+          %{"var" => "sam_tool_to_be_used"},
+          [
+            %{"key" => "ILMT", "value" => 1},
+            %{"key" => "Flexera", "value" => 1.2},
+            %{"key" => "ServiceNow", "value" => 1.15}
+          ],
+          "key",
+          "value"
+        ]
+      }
+      data = %{"sam_tool_to_be_used" => "Flexera"}
+      assert JsonLogicXL.resolve(logic, data) == 1.2
+    end
+    test "gets table from data variable" do
+      logic = %{
+        "if" => [
+          %{">" => [%{"var" => "num_seats__pub"}, 10]},
+          "custom",
+          %{
+            "xlookup" => [
+              %{"var" => "course_name__pub"},
+              %{"var" => "tbl_trng_crss"},
+              "Name",
+              "Cost"
+            ]
+          }
+        ]
+      }
+      data = %{
+        "course_name__pub" => "CSAM",
+        "num_seats__pub" => 8,
+        "tbl_trng_crss" => [
+          %{"Cost" => 30, "Name" => "CSAM", "Price" => 4000},
+          %{"Cost" => 60, "Name" => "Scuba Diving", "Price" => 10000},
+          %{"Cost" => 15, "Name" => "Pottery", "Price" => 1000}
+        ]
+      }
+      assert JsonLogicXL.resolve(logic, data) == 30
+    end
+    test "no match found" do
+      logic = %{
+        "xlookup" => [
+          "unknown",
+          [
+            %{"key" => "ILMT", "value" => 1},
+          ],
+          "key",
+          "value"
+        ]
+      }
+      assert JsonLogicXL.resolve(logic) == nil
+    end
+  end
+
+  describe "ln natural log" do
+    test "natural log of 9" do
+      logic = %{
+        "ln" => "9"
+      }
+      assert_approx_eq(JsonLogicXL.resolve(logic), 2.1972245)
+    end
+    test "natural log of 1" do
+      logic = %{
+        "ln" => 1
+      }
+      assert JsonLogicXL.resolve(logic) == 0
     end
   end
 


### PR DESCRIPTION
- Breaks out our custom extension operators into a separate file (instead of adding onto the already 1000+ line json_logic.ex file)
- Adds xlookup and logarithm operations/operators.