### PR TITLE
feat(ENBL-36): add AI code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,25 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    uses: Anglepoint-AI-Enablement/angleploint-review-bot/.github/workflows/review.yml@main
+    with:
+      additional_prompt: |
+        This is an Elixir library extending JsonLogic. The eng-index does not have Elixir-specific standards yet, so apply general code standards focusing on maintainability, readability, correctness, and security.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ENG_INDEX_APP_ID: ${{ secrets.ENG_INDEX_APP_ID }}
+      ENG_INDEX_PRIVATE_KEY: ${{ secrets.ENG_INDEX_PRIVATE_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   review:
-    uses: Anglepoint-AI-Enablement/angleploint-review-bot/.github/workflows/review.yml@main
+    uses: Anglepoint-AI-Enablement/anglepoint-review-bot/.github/workflows/review.yml@main
     with:
       additional_prompt: |
         This is an Elixir library extending JsonLogic. The eng-index does not have Elixir-specific standards yet, so apply general code standards focusing on maintainability, readability, correctness, and security.


### PR DESCRIPTION
Adds the shared AI code review workflow that uses the reusable action from angleploint-review-bot. Reviews PRs against eng-index standards using Claude.